### PR TITLE
ci: use Dart only when generating template

### DIFF
--- a/.github/workflows/generate_template.yaml
+++ b/.github/workflows/generate_template.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install melos
         run: dart pub global activate melos 3.1.1
       - name: Initialize melos
-        run: melos bs
+        run: melos bs --no-flutter
       - name: Generate template
         run: melos run BG
       - name: Create PR


### PR DESCRIPTION
## Details

Bootstrap Dart-only projects, which include the template generator package.
