### PR TITLE
chore(ref): report missing localized messages

### DIFF
--- a/packages/reference_app/.gitignore
+++ b/packages/reference_app/.gitignore
@@ -29,6 +29,7 @@
 /.pub-cache/
 /.pub/
 /build/
+/**/untranslated-messages.json
 
 # Symbolication related
 /app.*.symbols

--- a/packages/reference_app/l10n.yaml
+++ b/packages/reference_app/l10n.yaml
@@ -2,3 +2,4 @@ arb-dir: lib/l10n/arb/
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
 nullable-getter: false
+untranslated-messages-file: lib/l10n/arb/untranslated-messages.json


### PR DESCRIPTION
## Details

Update l10n setup to report messages that have not been localized in any of the locale ARB files.
