### PR TITLE
docs(brick): deep linking support w/ `auto_route`

### DIFF
--- a/packages/brick/README.md
+++ b/packages/brick/README.md
@@ -6,8 +6,11 @@ Create a [Flutter][flutter_web_link] app, **_al toque_** (_quickly_).
 
 - **Internationalization:**\
   Supported by following the [official internationalization guide for Flutter][flutter_docs_internationalization_link].
+- **Deep linking:**\
+  Supported with the [`auto_route` package][flutter_package_auto_route] package.
 
 <!-- LINKS -->
 
 [flutter_docs_internationalization_link]: https://docs.flutter.dev/ui/accessibility-and-localization/internationalization
+[flutter_package_auto_route]: https://pub.dev/packages/auto_route
 [flutter_web_link]: https://flutter.dev/


### PR DESCRIPTION
## Details

Describe deep linking support with `auto_route`.