### PR TITLE
feat(ref): nav 2.0 with `go_router`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 
 # Generated source files
 /**/__brick__/**/*.gr.dart
+/**/__brick__/**/*.g.dart
 
 # Project platforms
 /**/__brick__/**/android/

--- a/packages/reference_app/build.yaml
+++ b/packages/reference_app/build.yaml
@@ -1,6 +1,8 @@
 targets:
   $default:
     builders:
+      #*w 1v 6> w*#
+      #{{#use_auto_route_router}}#
       auto_route_generator:auto_route_generator:
         options:
           enable_cached_builds: true
@@ -11,3 +13,11 @@ targets:
           enable_cached_builds: true
         generate_for:
           - lib/routing/router.dart
+      #{{/use_auto_route_router}}#
+      #{{#use_go_router_router}}#
+      go_router_builder:
+        options:
+        generate_for:
+          - lib/routing/router.dart
+      #{{/use_go_router_router}}#
+      #*w 1v w*#

--- a/packages/reference_app/lib/app/presentation/app.dart
+++ b/packages/reference_app/lib/app/presentation/app.dart
@@ -1,14 +1,13 @@
 import 'package:altoke_app/l10n/l10n.dart';
-import 'package:altoke_app/routing/routing.dart';
 import 'package:flutter/material.dart';
 
 class MyApp extends StatelessWidget {
   const MyApp({
-    required this.router,
+    required this.routerConfig,
     super.key,
   });
 
-  final AppRouter router;
+  final RouterConfig<Object> routerConfig;
 
   @override
   Widget build(BuildContext context) {
@@ -22,7 +21,7 @@ class MyApp extends StatelessWidget {
       onGenerateTitle: (BuildContext context) => context.l10n.appTitle,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      routerConfig: router.config(),
+      routerConfig: routerConfig,
     );
   }
 }

--- a/packages/reference_app/lib/home/presentation/example_tiles.dart
+++ b/packages/reference_app/lib/home/presentation/example_tiles.dart
@@ -1,6 +1,8 @@
 import 'package:altoke_app/l10n/l10n.dart';
 import 'package:altoke_app/routing/routing.dart';
+/*{{#use_auto_route_router}}*/
 import 'package:auto_route/auto_route.dart';
+/*{{/use_auto_route_router}}*/
 import 'package:flutter/material.dart';
 
 class CounterExampleTile extends StatelessWidget {
@@ -17,9 +19,23 @@ class CounterExampleTile extends StatelessWidget {
         key: const Key('<counter::example-tile::title>'),
       ),
       onTap: () {
-        context.navigateTo(
-          CounterRoute(),
-        );
+        /*w 1v w*/
+        /*remove-start*/
+        final routerPackage = RouterPackage.of(context);
+        switch (routerPackage) {
+          case RouterPackage.autoRoute:
+            /*remove-end*/
+            /*{{#use_auto_route_router}}*/
+            context.navigateTo(CounterRoute());
+          /*{{/use_auto_route_router}}*/
+          /*remove-start*/
+          case RouterPackage.goRouter: /*remove-end*/
+            /*{{#use_go_router_router}}*/
+            CounterRouteData().go(context);
+          /*{{/use_go_router_router}}*/
+          /*remove-start*/
+        } /*remove-end*/
+        /*w 1v w*/
       },
     );
   }

--- a/packages/reference_app/lib/main.dart
+++ b/packages/reference_app/lib/main.dart
@@ -1,12 +1,33 @@
 import 'package:altoke_app/app/app.dart';
 import 'package:altoke_app/routing/routing.dart';
 import 'package:flutter/material.dart';
+/*{{#use_go_router_router}}*/
+import 'package:go_router/go_router.dart';
+/*{{/use_go_router_router}}*/
 
 void main() {
-  final router = AppRouter();
+  WidgetsFlutterBinding.ensureInitialized();
+  final routerConfig = /*remove-start*/ switch (RouterPackage.fromEnv) {
+    RouterPackage.autoRoute =>
+      /*remove-end*/
+      /*{{#use_auto_route_router}}*/
+      AppRouter().config()
+    /*{{/use_auto_route_router}}*/
+    /*remove-start*/,
+    RouterPackage.goRouter => /*remove-end*/
+      /*{{#use_go_router_router}}*/
+      GoRouter(routes: $appRoutes)
+    /*{{/use_go_router_router}}*/
+    /*remove-start*/,
+  } /*remove-end*/;
   runApp(
-    MyApp(
-      router: router,
-    ),
+    /*remove-start*/
+    InheritedRouterPackage(
+      package: RouterPackage.fromEnv,
+      child: /*remove-end*/ MyApp(
+        routerConfig: routerConfig as RouterConfig<Object>,
+      ),
+      /*remove-start*/
+    ), /*remove-end*/
   );
 }

--- a/packages/reference_app/lib/routing/router.dart
+++ b/packages/reference_app/lib/routing/router.dart
@@ -1,6 +1,15 @@
 import 'package:altoke_app/routing/routing.dart';
+/*{{#use_auto_route_router}}*/
 import 'package:auto_route/auto_route.dart';
+/*{{/use_auto_route_router}}*/
+import 'package:flutter/widgets.dart';
+/*{{#use_go_router_router}}*/
+import 'package:go_router/go_router.dart';
 
+part 'router.g.dart';
+/*{{/use_go_router_router}}*/
+
+/*{{#use_auto_route_router}}*/
 @AutoRouterConfig(
   generateForDir: ['lib/routing/'],
 )
@@ -21,4 +30,80 @@ class AppRouter extends $AppRouter {
       page: CounterRoute.page,
     ),
   ];
+}
+/*{{/use_auto_route_router}}*/
+
+/*{{#use_go_router_router}}*/
+@TypedGoRoute<HomeRouteData>(
+  path: '/',
+  name: 'HomeRoute',
+)
+class HomeRouteData extends GoRouteData {
+  const HomeRouteData();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const HomeScreen();
+  }
+}
+
+@TypedGoRoute<CounterRouteData>(
+  path: '/counter',
+  name: 'CounterRoute',
+)
+class CounterRouteData extends GoRouteData {
+  const CounterRouteData();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const CounterScreen();
+  }
+}
+/*{{/use_go_router_router}}*/
+
+/*drop*/
+enum RouterPackage {
+  autoRoute('auto_route'),
+  goRouter('go_router'),
+  ;
+
+  const RouterPackage(this.identifier);
+
+  final String identifier;
+
+  static late final fromEnv = RouterPackage.values.firstWhere(
+    (routerPackage) => routerPackage.identifier == routerIdentifier,
+  );
+
+  static RouterPackage of(BuildContext context) {
+    return InheritedRouterPackage.of(context).package;
+  }
+}
+
+@visibleForTesting
+const routerIdentifier = String.fromEnvironment('REF_ALTOKE_ROUTER');
+
+class InheritedRouterPackage extends InheritedWidget {
+  const InheritedRouterPackage({
+    super.key,
+    required this.package,
+    required super.child,
+  });
+
+  final RouterPackage package;
+
+  static InheritedRouterPackage? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<InheritedRouterPackage>();
+  }
+
+  static InheritedRouterPackage of(BuildContext context) {
+    final InheritedRouterPackage? result = maybeOf(context);
+    assert(result != null, 'No InheritedRouterPackage found in context');
+    return result!;
+  }
+
+  @override
+  bool updateShouldNotify(InheritedRouterPackage oldWidget) {
+    return package != oldWidget.package;
+  }
 }

--- a/packages/reference_app/lib/routing/router.g.dart
+++ b/packages/reference_app/lib/routing/router.g.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'router.dart';
+
+// **************************************************************************
+// GoRouterGenerator
+// **************************************************************************
+
+List<RouteBase> get $appRoutes => [
+      $homeRouteData,
+      $counterRouteData,
+    ];
+
+RouteBase get $homeRouteData => GoRouteData.$route(
+      path: '/',
+      name: 'HomeRoute',
+      factory: $HomeRouteDataExtension._fromState,
+    );
+
+extension $HomeRouteDataExtension on HomeRouteData {
+  static HomeRouteData _fromState(GoRouterState state) => const HomeRouteData();
+
+  String get location => GoRouteData.$location(
+        '/',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $counterRouteData => GoRouteData.$route(
+      path: '/counter',
+      name: 'CounterRoute',
+      factory: $CounterRouteDataExtension._fromState,
+    );
+
+extension $CounterRouteDataExtension on CounterRouteData {
+  static CounterRouteData _fromState(GoRouterState state) =>
+      const CounterRouteData();
+
+  String get location => GoRouteData.$location(
+        '/counter',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}

--- a/packages/reference_app/lib/routing/routes/counter/screen.dart
+++ b/packages/reference_app/lib/routing/routes/counter/screen.dart
@@ -1,10 +1,14 @@
 import 'package:altoke_app/counter/counter.dart';
+/*{{#use_auto_route_router}}*/
 import 'package:auto_route/auto_route.dart';
+/*{{/use_auto_route_router}}*/
 import 'package:flutter/material.dart';
 
+/*{{#use_auto_route_router}}*/
 @RoutePage(
   name: 'CounterRoute',
 )
+/*{{/use_auto_route_router}}*/
 class CounterScreen extends StatefulWidget {
   const CounterScreen({
     super.key,

--- a/packages/reference_app/lib/routing/routes/home/screen.dart
+++ b/packages/reference_app/lib/routing/routes/home/screen.dart
@@ -1,10 +1,14 @@
 import 'package:altoke_app/home/home.dart';
+/*{{#use_auto_route_router}}*/
 import 'package:auto_route/auto_route.dart';
+/*{{/use_auto_route_router}}*/
 import 'package:flutter/material.dart';
 
+/*{{#use_auto_route_router}}*/
 @RoutePage(
   name: 'HomeRoute',
 )
+/*{{/use_auto_route_router}}*/
 class HomeScreen extends StatelessWidget {
   const HomeScreen({
     super.key,

--- a/packages/reference_app/lib/routing/routing.dart
+++ b/packages/reference_app/lib/routing/routing.dart
@@ -1,4 +1,6 @@
 export 'router.dart';
+/*{{#use_auto_route_router}}*/
 export 'router.gr.dart';
+/*{{/use_auto_route_router}}*/
 export 'routes/counter/screen.dart';
 export 'routes/home/screen.dart';

--- a/packages/reference_app/pubspec.yaml
+++ b/packages/reference_app/pubspec.yaml
@@ -8,18 +8,36 @@ environment:
   flutter: 3.13.0
 
 dependencies:
+  #*w 1v 2> w*#
+  #{{#use_auto_route_router}}#
   auto_route: ^7.8.1
+  #*w 1v 2> w*#
+  #{{/use_auto_route_router}}#
   flutter:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  #*w 1v 2> w*#
+  #{{#use_go_router_router}}#
+  go_router: ^10.1.2
+  #*w 1v 2> w*#
+  #{{/use_go_router_router}}#
   intl: ^0.18.1
 
 dev_dependencies:
+  #*w 1v 2> w*#
+  #{{#use_auto_route_router}}#
   auto_route_generator: ^7.3.1
+  #*w 1v 2> w*#
+  #{{/use_auto_route_router}}#
   build_runner: ^2.4.6
   flutter_test:
     sdk: flutter
+  #*w 1v 2> w*#
+  #{{#use_go_router_router}}#
+  go_router_builder: ^2.3.1
+  #*w 1v 2> w*#
+  #{{/use_go_router_router}}#
   mocktail: ^1.0.0
 
 flutter:

--- a/packages/reference_app/test/app/presentation/app_test.dart
+++ b/packages/reference_app/test/app/presentation/app_test.dart
@@ -1,8 +1,11 @@
 import 'package:altoke_app/app/app.dart';
 import 'package:altoke_app/routing/routing.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 
 void main() {
+/*w 1v w*/
+/*{{#use_auto_route_router}}*/
   testWidgets(
     '''
 
@@ -12,11 +15,31 @@ WHEN the app is built
 THEN the home screen should be shown
 ''',
     (tester) async {
-      final router = AppRouter();
-      await tester.pumpWidget(MyApp(router: router));
+      final routerConfig = AppRouter().config();
+      await tester.pumpWidget(MyApp(routerConfig: routerConfig));
       await tester.pumpAndSettle();
       final homeScreenFinder = find.byType(HomeScreen);
       expect(homeScreenFinder, findsOneWidget);
     },
   );
+/*{{/use_auto_route_router}}*/
+
+/*{{#use_go_router_router}}*/
+  testWidgets(
+    '''
+
+GIVEN an app
+AND an app router
+WHEN the app is built
+THEN the home screen should be shown
+''',
+    (tester) async {
+      final routerConfig = GoRouter(routes: $appRoutes);
+      await tester.pumpWidget(MyApp(routerConfig: routerConfig));
+      await tester.pumpAndSettle();
+      final homeScreenFinder = find.byType(HomeScreen);
+      expect(homeScreenFinder, findsOneWidget);
+    },
+  );
+/*{{/use_go_router_router}}*/
 }

--- a/packages/reference_app/test/helpers/app_tester.dart
+++ b/packages/reference_app/test/helpers/app_tester.dart
@@ -1,61 +1,11 @@
 import 'package:altoke_app/l10n/l10n.dart';
-import 'package:altoke_app/routing/routing.dart';
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 extension AppTester on WidgetTester {
-  Future<void> pumpRouteAppWithInitialRoute(
-    String initialPath,
+  Future<void> pumpTestableWidget(
+    Widget testableWidget,
   ) async {
-    final router = AppRouter();
-    await pumpWidget(
-      MaterialApp.router(
-        theme: ThemeData.light(
-          useMaterial3: true,
-        ),
-        darkTheme: ThemeData.dark(
-          useMaterial3: true,
-        ),
-        onGenerateTitle: (BuildContext context) => context.l10n.appTitle,
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        routerConfig: router.config(
-          deepLinkBuilder: (deepLink) => DeepLink.path(initialPath),
-        ),
-      ),
-    );
-    await pumpAndSettle();
-  }
-
-  Future<void> pumpRoutedAppWithTestableWidget({
-    required Widget testableWidget,
-    required RoutingController routingController,
-  }) async {
-    await pumpWidget(
-      MaterialApp(
-        theme: ThemeData.light(
-          useMaterial3: true,
-        ),
-        darkTheme: ThemeData.dark(
-          useMaterial3: true,
-        ),
-        onGenerateTitle: (BuildContext context) => context.l10n.appTitle,
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: RouterScope(
-          controller: routingController,
-          inheritableObserversBuilder: () => [],
-          child: testableWidget,
-          stateHash: 0,
-        ),
-      ),
-    );
-  }
-
-  Future<void> pumpSimpleAppWithTestableWidget({
-    required Widget testableWidget,
-  }) async {
     await pumpWidget(
       MaterialApp(
         theme: ThemeData.light(

--- a/packages/reference_app/test/helpers/l10n_helpers.dart
+++ b/packages/reference_app/test/helpers/l10n_helpers.dart
@@ -66,8 +66,8 @@ void testLocalizedWidget(
         localizedTextSelector,
         literalText,
       ) = l10nCase;
-      await tester.pumpSimpleAppWithTestableWidget(
-        testableWidget: Builder(
+      await tester.pumpTestableWidget(
+        Builder(
           builder: (context) => Localizations.override(
             context: context,
             locale: locale,

--- a/packages/reference_app/test/helpers/routing_helpers.dart
+++ b/packages/reference_app/test/helpers/routing_helpers.dart
@@ -1,7 +1,10 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockRoutingController extends Mock implements RoutingController {}
+
+class MockGoRouter extends Mock implements GoRouter {}
 
 void registerRoutingFallbackValues() {
   registerFallbackValue(PageRouteInfo(''));

--- a/packages/reference_app/test/home/presentation/example_tiles_test.dart
+++ b/packages/reference_app/test/home/presentation/example_tiles_test.dart
@@ -1,7 +1,9 @@
 import 'package:altoke_app/home/home.dart';
 import 'package:altoke_app/routing/routing.dart';
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../helpers/helpers.dart';
@@ -43,6 +45,7 @@ THEN the tile should include the localized label
     variant: localizationVAriant,
   );
 
+/*{{#use_auto_route_router}}*/
   testWidgets(
     '''
 
@@ -56,11 +59,18 @@ THEN the counter route should be visited
       final routingController = MockRoutingController();
       when(() => routingController.navigate(any()))
           .thenAnswer((_) async => null);
-      await tester.pumpRoutedAppWithTestableWidget(
-        routingController: routingController,
-        testableWidget: Scaffold(
-          body: CounterExampleTile(),
-        ),
+      await tester.pumpTestableWidget(
+        /*remove-start*/ InheritedRouterPackage(
+          package: RouterPackage.autoRoute,
+          child: /*remove-end*/ RouterScope(
+            controller: routingController,
+            inheritableObserversBuilder: () => [],
+            stateHash: 0,
+            child: Scaffold(
+              body: CounterExampleTile(),
+            ),
+          ), /*remove-start*/
+        ), /*remove-end*/
       );
       final counterExampleTileFinder = find.byType(CounterExampleTile);
       await tester.tap(counterExampleTileFinder);
@@ -68,4 +78,37 @@ THEN the counter route should be visited
       verifyNoMoreInteractions(routingController);
     },
   );
+/*{{/use_auto_route_router}}*/
+
+/*{{#use_go_router_router}}*/
+  testWidgets(
+    '''
+
+GIVEN a counter example tile
+AND an injected router
+WHEN the tile is tapped
+THEN the counter route should be visited
+''',
+    (tester) async {
+      registerRoutingFallbackValues();
+      final goRouter = MockGoRouter();
+      when(() => goRouter.go(any())).thenAnswer((_) async => null);
+      await tester.pumpTestableWidget(
+        /*remove-start*/ InheritedRouterPackage(
+          package: RouterPackage.goRouter,
+          child: /*remove-end*/ InheritedGoRouter(
+            goRouter: goRouter,
+            child: Scaffold(
+              body: CounterExampleTile(),
+            ),
+          ), /*remove-start*/
+        ), /*remove-end*/
+      );
+      final counterExampleTileFinder = find.byType(CounterExampleTile);
+      await tester.tap(counterExampleTileFinder);
+      verify(() => goRouter.go(CounterRouteData().location)).called(1);
+      verifyNoMoreInteractions(goRouter);
+    },
+  );
+/*{{/use_go_router_router}}*/
 }

--- a/packages/reference_app/test/routing/routes/counter/screen_test.dart
+++ b/packages/reference_app/test/routing/routes/counter/screen_test.dart
@@ -1,10 +1,13 @@
+import 'package:altoke_app/app/app.dart';
 import 'package:altoke_app/routing/routing.dart';
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import '../../../helpers/helpers.dart';
+import 'package:go_router/go_router.dart';
 
 void main() {
+/*w 1v w*/
+/*{{#use_auto_route_router}}*/
   testWidgets(
     '''
 
@@ -14,7 +17,14 @@ WHEN the app starts
 THEN the counter screen should be shown
 ''',
     (tester) async {
-      await tester.pumpRouteAppWithInitialRoute('/counter');
+      await tester.pumpWidget(
+        MyApp(
+          routerConfig: AppRouter().config(
+            deepLinkBuilder: (_) => DeepLink.path('/counter'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
       final counterScreenFinder = find.byType(CounterScreen);
       expect(counterScreenFinder, findsOneWidget);
     },
@@ -29,7 +39,14 @@ WHEN the increment button is tapped
 THEN the counter value should be 1
 ''',
     (tester) async {
-      await tester.pumpRouteAppWithInitialRoute('/counter');
+      await tester.pumpWidget(
+        MyApp(
+          routerConfig: AppRouter().config(
+            deepLinkBuilder: (_) => DeepLink.path('/counter'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
       expect(find.text('0'), findsOneWidget);
       expect(find.text('1'), findsNothing);
       final incrementButtonFinder = find.byType(FloatingActionButton);
@@ -39,4 +56,58 @@ THEN the counter value should be 1
       expect(find.text('1'), findsOneWidget);
     },
   );
+/*{{/use_auto_route_router}}*/
+
+/*{{#use_go_router_router}}*/
+  testWidgets(
+    '''
+
+GIVEN a routed app
+├─ THAT starts with the counter path
+WHEN the app starts
+THEN the counter screen should be shown
+''',
+    (tester) async {
+      await tester.pumpWidget(
+        MyApp(
+          routerConfig: GoRouter(
+            routes: $appRoutes,
+            initialLocation: '/counter',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      final counterScreenFinder = find.byType(CounterScreen);
+      expect(counterScreenFinder, findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    '''
+
+GIVEN a counter screen
+├─ THAT starts with a counter value of 0
+WHEN the increment button is tapped
+THEN the counter value should be 1
+''',
+    (tester) async {
+      await tester.pumpWidget(
+        MyApp(
+          routerConfig: GoRouter(
+            routes: $appRoutes,
+            initialLocation: '/counter',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('0'), findsOneWidget);
+      expect(find.text('1'), findsNothing);
+      final incrementButtonFinder = find.byType(FloatingActionButton);
+      await tester.tap(incrementButtonFinder);
+      await tester.pump();
+      expect(find.text('0'), findsNothing);
+      expect(find.text('1'), findsOneWidget);
+    },
+  );
+/*{{/use_go_router_router}}*/
 }

--- a/packages/reference_app/test/routing/routes/home/screen_test.dart
+++ b/packages/reference_app/test/routing/routes/home/screen_test.dart
@@ -1,9 +1,12 @@
+import 'package:altoke_app/app/app.dart';
 import 'package:altoke_app/routing/routing.dart';
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import '../../../helpers/helpers.dart';
+import 'package:go_router/go_router.dart';
 
 void main() {
+/*w 1v w*/
+/*{{#use_auto_route_router}}*/
   testWidgets(
     '''
 
@@ -13,9 +16,42 @@ WHEN the app starts
 THEN the home screen should be shown
 ''',
     (tester) async {
-      await tester.pumpRouteAppWithInitialRoute('/');
+      await tester.pumpWidget(
+        MyApp(
+          routerConfig: AppRouter().config(
+            deepLinkBuilder: (_) => DeepLink.path('/'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
       final homeScreenFinder = find.byType(HomeScreen);
       expect(homeScreenFinder, findsOneWidget);
     },
   );
+/*{{/use_auto_route_router}}*/
+
+/*{{#use_go_router_router}}*/
+  testWidgets(
+    '''
+
+GIVEN a routed app
+├─ THAT starts with the home path
+WHEN the app starts
+THEN the home screen should be shown
+''',
+    (tester) async {
+      await tester.pumpWidget(
+        MyApp(
+          routerConfig: GoRouter(
+            routes: $appRoutes,
+            initialLocation: '/',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      final homeScreenFinder = find.byType(HomeScreen);
+      expect(homeScreenFinder, findsOneWidget);
+    },
+  );
+/*{{/use_go_router_router}}*/
 }


### PR DESCRIPTION
## Details

Use the [`go_router` package](https://pub.dev/packages/go_router) for navigation with Router API (aka Navigation 2.0) support.