### PR TITLE
feat(bg): multi doc-types remotion

### DIFF
--- a/packages/brick_generator/lib/src/reference_file.dart
+++ b/packages/brick_generator/lib/src/reference_file.dart
@@ -6,7 +6,7 @@ import 'package:meta/meta.dart';
 abstract class AltokeRegexp {
   @visibleForTesting
   static final remotionRegexp = RegExp(
-    r'([\/#]\*drop\*[\/#].*)|((\s+)?[\/#]\*remove-start\*[\/#]([\s\S]*?)[\/#]\*remove-end\*[\/#](\s+)?)',
+    r'(((\/)|(#)|(<!--))\*drop\*((\/)|(#)|(-->)).*)|((\s+)?((\/)|(#)|(<!--))\*remove-start\*((\/)|(#)|(-->))([\s\S]*?)((\/)|(#)|(<!--))\*remove-end\*((\/)|(#)|(-->))(\s+)?)',
     dotAll: true,
   );
 


### PR DESCRIPTION
## Details

Support inline comment annotations for different type of docs for content remotion.

The resulting supported comments meet the following patterns:

- From `/*remove-start*/` to `/*remove-end*/`.
- From `#*remove-start*#` to `#*remove-end*#`.
- From `<!--*remove-start*-->` to `<!--*remove-end*-->`.
- From `/*drop*/` to the end of the file.
- From `#*drop*#` to the end of the file.
- From `<!--*drop*-->` to the end of the file.