### PR TITLE
ci: template updates PR labels

### DIFF
--- a/.github/workflows/generate_template.yaml
+++ b/.github/workflows/generate_template.yaml
@@ -36,7 +36,9 @@ jobs:
           title: "chore(brick): update template"
           body: Update template.
           delete-branch: true
-          labels: bot
+          labels: |
+            bot
+            p:brick
           author: Altoke Bot <altoke.bot@users.noreply.github.com>
           committer: Altoke Bot <altoke.bot@users.noreply.github.com>
           assignees: mrverdant13


### PR DESCRIPTION
## Details

Use `bot` and `p:brick` as PR labels when updating brick template.