### PR TITLE
ci(brick): safer CI trigger condition

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,8 +9,11 @@ on:
     branches:
       - main
     paths:
+      - .github/workflows/e2e.yaml
       - packages/brick/**
       - packages/brick_e2e/**
+      - melos.yaml
+      - pubspec.yaml
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
## Details

Use safer condition when triggering the E2E tests for the brick project.