### PR TITLE
ci: ignore root melos setup changes in E2E triggers

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,6 @@ on:
       - 'packages/brick/**'
       - '!packages/brick/*.md'
       - 'packages/brick_e2e/**'
-      - 'melos.yaml'
       - 'pubspec.yaml'
   workflow_dispatch: {}
 


### PR DESCRIPTION
## Details

Ignore root melos setup changes in triggering filters for the E2E tests.