### PR TITLE
ci: ignore brick docs files on CI workflow triggers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'packages/brick/*.md'
 
 jobs:
   min-conditions:


### PR DESCRIPTION
## Details

Ignore documentation files in filters that trigger the CI workflow.