### PR TITLE
fix(brick): add missing SQLite DB option

### DIFF
--- a/packages/brick/hooks/database/database.dart
+++ b/packages/brick/hooks/database/database.dart
@@ -8,6 +8,7 @@ enum Database {
   isar('Isar', 'isar'),
   realm('Realm', 'realm'),
   sembast('Sembast', 'sembast'),
+  sqlite('SQLite', 'sqlite'),
   ;
 
   const Database(this.label, this.varIdentifier);


### PR DESCRIPTION
## Details

Add missing pre-hook option to use SQLite as local database.