### PR TITLE
fix(brick): ignore coverage folders

### DIFF
--- a/packages/brick/hooks/.gitignore
+++ b/packages/brick/hooks/.gitignore
@@ -1,3 +1,10 @@
+# See https://www.dartlang.org/guides/libraries/private-files
+
+# Files and directories created by pub
 /.dart_tool/
+/.packages
 /build/
 /pubspec.lock
+
+# Testing
+/coverage/

--- a/packages/brick_e2e/.gitignore
+++ b/packages/brick_e2e/.gitignore
@@ -1,3 +1,10 @@
+# See https://www.dartlang.org/guides/libraries/private-files
+
+# Files and directories created by pub
 /.dart_tool/
+/.packages
 /build/
 /pubspec.lock
+
+# Testing
+/coverage/


### PR DESCRIPTION
## Details

Ignore coverage folders for brick sub-projects.