### PR TITLE
fix(bg): ignore coverage folder

### DIFF
--- a/packages/brick_generator/.gitignore
+++ b/packages/brick_generator/.gitignore
@@ -1,3 +1,10 @@
+# See https://www.dartlang.org/guides/libraries/private-files
+
+# Files and directories created by pub
 /.dart_tool/
+/.packages
 /build/
 /pubspec.lock
+
+# Testing
+/coverage/


### PR DESCRIPTION
## Details

Ignore coverage folder for the brick generator.