### PR TITLE
fix: drop unnecessary Flutter version constraint

### DIFF
--- a/packages/reference_app/packages/tasks_storage/_conditional_dir___use_isar_database___tasks_isar_storage/pubspec.yaml
+++ b/packages/reference_app/packages/tasks_storage/_conditional_dir___use_isar_database___tasks_isar_storage/pubspec.yaml
@@ -5,7 +5,6 @@ publish_to: none
 
 environment:
   sdk: ">=3.3.1 <4.0.0"
-  flutter: ">=3.19.3 <4.0.0"
 
 dependencies:
   common:
@@ -19,7 +18,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.8
-  isar_flutter_libs: ^3.1.0+1
   isar_generator: ^3.1.0+1
   test: ^1.25.2
   very_good_analysis: ^5.1.0

--- a/packages/reference_app/packages/tasks_storage/_conditional_dir___use_realm_database___tasks_realm_storage/pubspec.yaml
+++ b/packages/reference_app/packages/tasks_storage/_conditional_dir___use_realm_database___tasks_realm_storage/pubspec.yaml
@@ -5,7 +5,6 @@ publish_to: none
 
 environment:
   sdk: ">=3.3.1 <4.0.0"
-  flutter: ">=3.19.3 <4.0.0"
 
 dependencies:
   common:


### PR DESCRIPTION
## Details

Drop unnecessary Flutter version constraint in internal reference packages.