### PR TITLE
 fix(altoke-common): explicitly drop `copyWith` from Freezed variant

### DIFF
--- a/bricks/altoke_common/reference/lib/src/types/_cf___use_freezed___optional.dart
+++ b/bricks/altoke_common/reference/lib/src/types/_cf___use_freezed___optional.dart
@@ -5,7 +5,7 @@ part '_cf___use_freezed___optional.freezed.dart';
 /// {@template common.optional}
 /// A representation of an optional value.
 /// {@endtemplate}
-@freezed
+@Freezed(copyWith: false)
 class FOptional<T extends Object?> with _$FOptional<T> {
   /// {@macro common.optional}
   const FOptional._();


### PR DESCRIPTION
## Description

Explicitly remove code generation for `Optional.copyWith` in the Freezed variant to be identifiable by potential wrapper classes.