### PR TITLE
feat(brick-generator): add annotation validation command

### DIFF
--- a/.github/workflows/generate_templates.yaml
+++ b/.github/workflows/generate_templates.yaml
@@ -62,6 +62,8 @@ jobs:
         run: melos bootstrap --scope=brick_generator
       - name: Set brick scope as unique relevant packages
         run: echo "MELOS_PACKAGES=${{ steps.build-brick-scope-name.outputs.brick-scope-name }}" >> "$GITHUB_ENV"
+      - name: Validate reference annotations
+        run: melos run brick.validate
       - name: Generate template
         run: melos run brick.gen
       - name: Create PR

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -339,6 +339,15 @@ melos:
       packageFilters:
         category:
           - scopes
+    brick.validate:
+      description: Validate brick reference annotations
+      run: >
+        dart run MELOS_ROOT_PATH/tools/brick_generator/lib/main.dart validate
+      exec:
+        concurrency: 1
+      packageFilters:
+        category:
+          - scopes
     brick.gen.all:
       description: Generate brick for all packages
       steps:

--- a/tools/brick_generator/lib/main.dart
+++ b/tools/brick_generator/lib/main.dart
@@ -1,66 +1,22 @@
-import 'dart:convert';
-import 'dart:io';
+import 'package:brick_generator/src/generate_brick.dart';
+import 'package:brick_generator/src/validate_references.dart';
 
-import 'package:brick_generator/src/models/brick_gen_data.dart';
-import 'package:brick_generator/src/models/brick_gen_options.dart';
-import 'package:brick_generator/src/reference_file.dart';
-import 'package:monorepo_elements/monorepo_elements.dart';
-import 'package:shell/git.dart';
-import 'package:shell/shell.dart';
-
+/// Brick generator CLI.
+///
+/// Subcommands:
+/// - `validate` — check reference files for annotation errors
+/// - default / `gen` — generate the brick template from references
 Future<void> main(List<String> args) async {
-  final brickGenDataFile = Files.brickGenData;
-  stdout.writeln('Brick generation data file: ${brickGenDataFile.path}');
-  late final BrickGenOptions brickGenOptions;
-  try {
-    final rawBrickGenData = await brickGenDataFile.readAsString();
-    final brickGenDataJson =
-        jsonDecode(rawBrickGenData) as Map<String, dynamic>;
-    brickGenOptions = BrickGenOptions.fromJson(brickGenDataJson);
-  } catch (e) {
-    throw Exception(
-      'Invalid brick generation data file. '
-      'Error: $e',
-    );
+  final subcommand = args.firstOrNull ?? 'gen';
+  switch (subcommand) {
+    case 'validate':
+      await validateReferences();
+    case 'gen':
+      await generateBrick();
+    default:
+      throw ArgumentError(
+        'Unknown subcommand "$subcommand". '
+        'Supported subcommands: gen, validate.',
+      );
   }
-  final scopeDir = Dirs.scope;
-  final referenceDir = scopeDir.descendantDir('reference');
-  if (!referenceDir.existsSync()) {
-    throw Exception('Reference directory not found (${referenceDir.path}).');
-  }
-  stdout.writeln('Reference directory: ${referenceDir.path}');
-  final brickTemplateDir = Dirs.brickTemplate;
-  stdout.writeln('Brick template directory: ${brickTemplateDir.path}');
-  final brickGenData = BrickGenData.fromOptions(
-    referenceAbsolutePath: referenceDir.path,
-    targetAbsolutePath: brickTemplateDir.path,
-    options: brickGenOptions,
-  );
-  stdout.writeln('Generating brick template...');
-
-  // Remove target directory.
-  if (Dirs.brickTemplate.existsSync()) {
-    await Shell.removeDirectory(Dirs.brickTemplate);
-  }
-
-  // Remove untracked files from reference directory.
-  await Git.cleanDirectory(referenceDir);
-
-  // Copy reference project.
-  await Shell.copyDirectory(
-    source: referenceDir,
-    destination: brickTemplateDir,
-  );
-
-  // Remove untracked files from brick directory.
-  await Git.cleanDirectory(brickTemplateDir);
-
-  // Parametrize template
-  final fsEntities = brickTemplateDir.listSync(recursive: true);
-  await Future.wait<void>([
-    for (final fsEntity in fsEntities)
-      if (fsEntity is File) fsEntity.parametrize(brickGenData: brickGenData),
-  ]);
-
-  stdout.writeln('Brick template successfully generated.');
 }

--- a/tools/brick_generator/lib/src/annotation_issue.dart
+++ b/tools/brick_generator/lib/src/annotation_issue.dart
@@ -1,0 +1,30 @@
+/// A single annotation validation problem in a reference file.
+class AnnotationIssue {
+  /// Creates an [AnnotationIssue].
+  const AnnotationIssue({
+    required this.filePath,
+    required this.line,
+    required this.message,
+    this.column,
+  });
+
+  /// Path to the file relative to the reference root, or absolute.
+  final String filePath;
+
+  /// One-based line number.
+  final int line;
+
+  /// Optional one-based column number.
+  final int? column;
+
+  /// Human-readable description of the problem.
+  final String message;
+
+  @override
+  String toString() {
+    final location = column == null
+        ? '$filePath:$line'
+        : '$filePath:$line:$column';
+    return '$location: $message';
+  }
+}

--- a/tools/brick_generator/lib/src/annotation_validator.dart
+++ b/tools/brick_generator/lib/src/annotation_validator.dart
@@ -1,0 +1,493 @@
+import 'dart:io';
+
+import 'package:brick_generator/src/annotation_issue.dart';
+import 'package:path/path.dart' as p;
+
+/// Validates brick-generator annotation markers in reference file contents.
+class AnnotationValidator {
+  /// Validates [content] and returns any issues found.
+  List<AnnotationIssue> validateContent(String content) {
+    final issues = <AnnotationIssue>[];
+    issues.addAll(_validatePairedMarkers(content, _removeMarkerSets));
+    issues.addAll(_validatePairedMarkers(content, _insertMarkerSets));
+    issues.addAll(_validateReplaceBlocks(content));
+    issues.addAll(_validatePartialBlocks(content));
+    return issues;
+  }
+
+  /// Validates a single [file] and returns issues with its path attached.
+  List<AnnotationIssue> validateFile(File file, {String? displayPath}) {
+    final path = displayPath ?? file.path;
+    if (_shouldSkipFile(path)) {
+      return const [];
+    }
+    late final String content;
+    try {
+      content = file.readAsStringSync();
+    } on FileSystemException {
+      return const [];
+    }
+    return validateContent(content)
+        .map(
+          (issue) => AnnotationIssue(
+            filePath: path,
+            line: issue.line,
+            column: issue.column,
+            message: issue.message,
+          ),
+        )
+        .toList();
+  }
+
+  /// Walks [referenceDir] recursively and validates every file.
+  List<AnnotationIssue> validateDirectory(Directory referenceDir) {
+    if (!referenceDir.existsSync()) {
+      throw ArgumentError('Reference directory not found (${referenceDir.path}).');
+    }
+    final issues = <AnnotationIssue>[];
+    for (final entity in referenceDir.listSync(recursive: true)) {
+      if (entity is! File) continue;
+      final relativePath = p.relative(entity.path, from: referenceDir.path);
+      issues.addAll(validateFile(entity, displayPath: relativePath));
+    }
+    return issues;
+  }
+
+  static const _ignoredExtensions = {
+    '.png',
+    '.webp',
+    '.jpg',
+    '.jpeg',
+    '.gif',
+    '.ico',
+    '.jar',
+    '.keystore',
+    '.p12',
+    '.jks',
+  };
+
+  static const _ignoredBasenames = {'.DS_Store'};
+
+  static bool _shouldSkipFile(String path) {
+    if (_ignoredExtensions.contains(p.extension(path))) return true;
+    if (_ignoredBasenames.contains(p.basename(path))) return true;
+    return false;
+  }
+
+  static final _removeMarkerSets = [
+    _MarkerSet(
+      flavor: '/* */',
+      start: RegExp(r'/\*(?:x-)?remove-start\*/'),
+      end: RegExp(r'/\*remove-end(?:-x)?\*/'),
+      blockName: 'remove',
+    ),
+    _MarkerSet(
+      flavor: '# #',
+      start: RegExp(r'#(?:x-)?remove-start#'),
+      end: RegExp(r'#remove-end(?:-x)?#'),
+      blockName: 'remove',
+    ),
+    _MarkerSet(
+      flavor: '<!-- -->',
+      start: RegExp(r'<!--(?:x-)?remove-start-->'),
+      end: RegExp(r'<!--remove-end(?:-x)?-->'),
+      blockName: 'remove',
+    ),
+  ];
+
+  static final _insertMarkerSets = [
+    _MarkerSet(
+      flavor: '/* */',
+      start: RegExp(r'/\*insert-start\*/'),
+      end: RegExp(r'/\*insert-end\*/'),
+      blockName: 'insert',
+    ),
+    _MarkerSet(
+      flavor: '# #',
+      start: RegExp(r'#insert-start#'),
+      end: RegExp(r'#insert-end#'),
+      blockName: 'insert',
+    ),
+    _MarkerSet(
+      flavor: '<!-- -->',
+      start: RegExp(r'<!--insert-start-->'),
+      end: RegExp(r'<!--insert-end-->'),
+      blockName: 'insert',
+    ),
+  ];
+
+  List<AnnotationIssue> _validatePairedMarkers(
+    String content,
+    List<_MarkerSet> markerSets,
+  ) {
+    final issues = <AnnotationIssue>[];
+    for (final markerSet in markerSets) {
+      final markers = <_Marker>[];
+      for (final match in markerSet.start.allMatches(content)) {
+        markers.add(
+          _Marker(
+            kind: _MarkerKind.start,
+            offset: match.start,
+            blockName: markerSet.blockName,
+            flavor: markerSet.flavor,
+          ),
+        );
+      }
+      for (final match in markerSet.end.allMatches(content)) {
+        markers.add(
+          _Marker(
+            kind: _MarkerKind.end,
+            offset: match.start,
+            blockName: markerSet.blockName,
+            flavor: markerSet.flavor,
+          ),
+        );
+      }
+      markers.sort((a, b) => a.offset.compareTo(b.offset));
+      final stack = <_Marker>[];
+      for (final marker in markers) {
+        switch (marker.kind) {
+          case _MarkerKind.start:
+            stack.add(marker);
+          case _MarkerKind.end:
+            if (stack.isEmpty) {
+              issues.add(
+                _issue(
+                  content,
+                  marker.offset,
+                  'Unmatched ${markerSet.blockName}-end marker (${markerSet.flavor})',
+                ),
+              );
+            } else {
+              stack.removeLast();
+            }
+        }
+      }
+      for (final unmatched in stack) {
+        issues.add(
+          _issue(
+            content,
+            unmatched.offset,
+            'Unmatched ${markerSet.blockName}-start marker (${markerSet.flavor})',
+          ),
+        );
+      }
+    }
+    return issues;
+  }
+
+  List<AnnotationIssue> _validateReplaceBlocks(String content) {
+    final issues = <AnnotationIssue>[];
+    for (final markerSet in _replaceMarkerSets) {
+      final markers = <_ReplaceMarker>[];
+      for (final match in markerSet.start.allMatches(content)) {
+        markers.add(_ReplaceMarker(_ReplaceMarkerKind.start, match.start, markerSet));
+      }
+      for (final match in markerSet.withMarker.allMatches(content)) {
+        markers.add(_ReplaceMarker(_ReplaceMarkerKind.withMarker, match.start, markerSet));
+      }
+      for (final match in markerSet.end.allMatches(content)) {
+        markers.add(_ReplaceMarker(_ReplaceMarkerKind.end, match.start, markerSet));
+      }
+      markers.sort((a, b) => a.offset.compareTo(b.offset));
+      var expecting = _ReplaceMarkerKind.start;
+      final stack = <int>[];
+      for (final marker in markers) {
+        switch (expecting) {
+          case _ReplaceMarkerKind.start:
+            if (marker.kind == _ReplaceMarkerKind.start) {
+              stack.add(marker.offset);
+              expecting = _ReplaceMarkerKind.withMarker;
+            } else {
+              issues.add(
+                _issue(
+                  content,
+                  marker.offset,
+                  'Unexpected ${marker.kind.label} before replace-start (${markerSet.flavor})',
+                ),
+              );
+            }
+          case _ReplaceMarkerKind.withMarker:
+            if (marker.kind == _ReplaceMarkerKind.withMarker) {
+              expecting = _ReplaceMarkerKind.end;
+            } else if (marker.kind == _ReplaceMarkerKind.start) {
+              issues.add(
+                _issue(
+                  content,
+                  marker.offset,
+                  'Nested replace-start is not supported (${markerSet.flavor})',
+                ),
+              );
+            } else {
+              issues.add(
+                _issue(
+                  content,
+                  marker.offset,
+                  'replace-end without a matching with marker (${markerSet.flavor})',
+                ),
+              );
+              expecting = _ReplaceMarkerKind.start;
+              stack.clear();
+            }
+          case _ReplaceMarkerKind.end:
+            if (marker.kind == _ReplaceMarkerKind.end) {
+              if (stack.isEmpty) {
+                issues.add(
+                  _issue(
+                    content,
+                    marker.offset,
+                    'Unmatched replace-end marker (${markerSet.flavor})',
+                  ),
+                );
+              } else {
+                stack.removeLast();
+              }
+              expecting = _ReplaceMarkerKind.start;
+            } else {
+              issues.add(
+                _issue(
+                  content,
+                  marker.offset,
+                  'replace-start block is missing replace-end (${markerSet.flavor})',
+                ),
+              );
+              if (marker.kind == _ReplaceMarkerKind.start) {
+                stack.add(marker.offset);
+                expecting = _ReplaceMarkerKind.withMarker;
+              } else {
+                expecting = _ReplaceMarkerKind.end;
+              }
+            }
+        }
+      }
+      for (final startOffset in stack) {
+        issues.add(
+          _issue(
+            content,
+            startOffset,
+            'Unmatched replace-start marker (${markerSet.flavor})',
+          ),
+        );
+      }
+    }
+    return issues;
+  }
+
+  static final _replaceMarkerSets = [
+    _ReplaceMarkerSet(
+      flavor: '/* */',
+      start: RegExp(r'/\*replace-start\*/'),
+      withMarker: RegExp(r'/\*with(?: +i\d+)?\*/'),
+      end: RegExp(r'/\*replace-end\*/'),
+    ),
+    _ReplaceMarkerSet(
+      flavor: '# #',
+      start: RegExp(r'#replace-start#'),
+      withMarker: RegExp(r'#with(?: +i\d+)?#'),
+      end: RegExp(r'#replace-end#'),
+    ),
+    _ReplaceMarkerSet(
+      flavor: '<!-- -->',
+      start: RegExp(r'<!--replace-start-->'),
+      withMarker: RegExp(r'<!--with(?: +i\d+)?-->'),
+      end: RegExp(r'<!--replace-end-->'),
+    ),
+  ];
+
+  List<AnnotationIssue> _validatePartialBlocks(String content) {
+    final issues = <AnnotationIssue>[];
+    for (final markerSet in _partialMarkerSets) {
+      final markers = <_PartialMarker>[];
+      for (final match in markerSet.start.allMatches(content)) {
+        final name = match.namedGroup('name') ?? '';
+        markers.add(
+          _PartialMarker(
+            kind: _PartialMarkerKind.start,
+            offset: match.start,
+            name: name,
+            flavor: markerSet.flavor,
+          ),
+        );
+      }
+      for (final match in markerSet.end.allMatches(content)) {
+        final name = match.namedGroup('name') ?? '';
+        markers.add(
+          _PartialMarker(
+            kind: _PartialMarkerKind.end,
+            offset: match.start,
+            name: name,
+            flavor: markerSet.flavor,
+          ),
+        );
+      }
+      markers.sort((a, b) => a.offset.compareTo(b.offset));
+      final stack = <_PartialMarker>[];
+      for (final marker in markers) {
+        switch (marker.kind) {
+          case _PartialMarkerKind.start:
+            stack.add(marker);
+          case _PartialMarkerKind.end:
+            if (stack.isEmpty) {
+              issues.add(
+                _issue(
+                  content,
+                  marker.offset,
+                  'Unmatched partial ^ marker for "${marker.name}" (${markerSet.flavor})',
+                ),
+              );
+            } else {
+              final start = stack.removeLast();
+              if (start.name != marker.name) {
+                issues.add(
+                  _issue(
+                    content,
+                    marker.offset,
+                    'partial ^ name "${marker.name}" does not match '
+                    'partial v name "${start.name}" (${markerSet.flavor})',
+                  ),
+                );
+              }
+            }
+        }
+      }
+      for (final unmatched in stack) {
+        issues.add(
+          _issue(
+            content,
+            unmatched.offset,
+            'Unmatched partial v marker for "${unmatched.name}" (${markerSet.flavor})',
+          ),
+        );
+      }
+    }
+    return issues;
+  }
+
+  static final _partialMarkerSets = [
+    _PartialMarkerSet(
+      flavor: '/* */',
+      start: RegExp(r'/\*partial v (?<name>.*?)\*/'),
+      end: RegExp(r'/\*partial \^ (?<name>.*?)\*/'),
+    ),
+    _PartialMarkerSet(
+      flavor: '# #',
+      start: RegExp(r'#partial v (?<name>.*?)#'),
+      end: RegExp(r'#partial \^ (?<name>.*?)#'),
+    ),
+    _PartialMarkerSet(
+      flavor: '<!-- -->',
+      start: RegExp(r'<!--partial v (?<name>.*?)-->'),
+      end: RegExp(r'<!--partial \^ (?<name>.*?)-->'),
+    ),
+  ];
+
+  AnnotationIssue _issue(String content, int offset, String message) {
+    return AnnotationIssue(
+      filePath: '',
+      line: _lineAt(content, offset),
+      column: _columnAt(content, offset),
+      message: message,
+    );
+  }
+
+  static int _lineAt(String content, int offset) {
+    return '\n'.allMatches(content.substring(0, offset)).length + 1;
+  }
+
+  static int _columnAt(String content, int offset) {
+    final lastNewline = content.lastIndexOf('\n', offset == 0 ? 0 : offset - 1);
+    return offset - lastNewline;
+  }
+}
+
+class _MarkerSet {
+  const _MarkerSet({
+    required this.flavor,
+    required this.start,
+    required this.end,
+    required this.blockName,
+  });
+
+  final String flavor;
+  final RegExp start;
+  final RegExp end;
+  final String blockName;
+}
+
+enum _MarkerKind { start, end }
+
+class _Marker {
+  const _Marker({
+    required this.kind,
+    required this.offset,
+    required this.blockName,
+    required this.flavor,
+  });
+
+  final _MarkerKind kind;
+  final int offset;
+  final String blockName;
+  final String flavor;
+}
+
+enum _ReplaceMarkerKind {
+  start,
+  withMarker,
+  end;
+
+  String get label => switch (this) {
+        _ReplaceMarkerKind.start => 'replace-start',
+        _ReplaceMarkerKind.withMarker => 'with',
+        _ReplaceMarkerKind.end => 'replace-end',
+      };
+}
+
+class _ReplaceMarkerSet {
+  const _ReplaceMarkerSet({
+    required this.flavor,
+    required this.start,
+    required this.withMarker,
+    required this.end,
+  });
+
+  final String flavor;
+  final RegExp start;
+  final RegExp withMarker;
+  final RegExp end;
+}
+
+class _ReplaceMarker {
+  const _ReplaceMarker(this.kind, this.offset, this.markerSet);
+
+  final _ReplaceMarkerKind kind;
+  final int offset;
+  final _ReplaceMarkerSet markerSet;
+}
+
+enum _PartialMarkerKind { start, end }
+
+class _PartialMarkerSet {
+  const _PartialMarkerSet({
+    required this.flavor,
+    required this.start,
+    required this.end,
+  });
+
+  final String flavor;
+  final RegExp start;
+  final RegExp end;
+}
+
+class _PartialMarker {
+  const _PartialMarker({
+    required this.kind,
+    required this.offset,
+    required this.name,
+    required this.flavor,
+  });
+
+  final _PartialMarkerKind kind;
+  final int offset;
+  final String name;
+  final String flavor;
+}

--- a/tools/brick_generator/lib/src/generate_brick.dart
+++ b/tools/brick_generator/lib/src/generate_brick.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:brick_generator/src/models/brick_gen_data.dart';
+import 'package:brick_generator/src/models/brick_gen_options.dart';
+import 'package:brick_generator/src/reference_file.dart';
+import 'package:monorepo_elements/monorepo_elements.dart';
+import 'package:shell/git.dart';
+import 'package:shell/shell.dart';
+
+/// Generates a brick template from the current scope's reference project.
+Future<void> generateBrick() async {
+  final brickGenDataFile = Files.brickGenData;
+  stdout.writeln('Brick generation data file: ${brickGenDataFile.path}');
+  late final BrickGenOptions brickGenOptions;
+  try {
+    final rawBrickGenData = await brickGenDataFile.readAsString();
+    final brickGenDataJson =
+        jsonDecode(rawBrickGenData) as Map<String, dynamic>;
+    brickGenOptions = BrickGenOptions.fromJson(brickGenDataJson);
+  } catch (e) {
+    throw Exception(
+      'Invalid brick generation data file. '
+      'Error: $e',
+    );
+  }
+  final scopeDir = Dirs.scope;
+  final referenceDir = scopeDir.descendantDir('reference');
+  if (!referenceDir.existsSync()) {
+    throw Exception('Reference directory not found (${referenceDir.path}).');
+  }
+  stdout.writeln('Reference directory: ${referenceDir.path}');
+  final brickTemplateDir = Dirs.brickTemplate;
+  stdout.writeln('Brick template directory: ${brickTemplateDir.path}');
+  final brickGenData = BrickGenData.fromOptions(
+    referenceAbsolutePath: referenceDir.path,
+    targetAbsolutePath: brickTemplateDir.path,
+    options: brickGenOptions,
+  );
+  stdout.writeln('Generating brick template...');
+
+  if (Dirs.brickTemplate.existsSync()) {
+    await Shell.removeDirectory(Dirs.brickTemplate);
+  }
+
+  await Git.cleanDirectory(referenceDir);
+
+  await Shell.copyDirectory(
+    source: referenceDir,
+    destination: brickTemplateDir,
+  );
+
+  await Git.cleanDirectory(brickTemplateDir);
+
+  final fsEntities = brickTemplateDir.listSync(recursive: true);
+  await Future.wait<void>([
+    for (final fsEntity in fsEntities)
+      if (fsEntity is File) fsEntity.parametrize(brickGenData: brickGenData),
+  ]);
+
+  stdout.writeln('Brick template successfully generated.');
+}

--- a/tools/brick_generator/lib/src/validate_references.dart
+++ b/tools/brick_generator/lib/src/validate_references.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+import 'package:brick_generator/src/annotation_validator.dart';
+import 'package:monorepo_elements/monorepo_elements.dart';
+
+/// Validates annotation markers in the current scope's reference directory.
+///
+/// Prints each issue to stderr and exits with code 1 when any are found.
+Future<void> validateReferences() async {
+  final scopeDir = Dirs.scope;
+  final referenceDir = scopeDir.descendantDir('reference');
+  if (!referenceDir.existsSync()) {
+    throw Exception('Reference directory not found (${referenceDir.path}).');
+  }
+  stdout.writeln('Validating annotations in: ${referenceDir.path}');
+
+  final validator = AnnotationValidator();
+  final issues = validator.validateDirectory(referenceDir);
+
+  if (issues.isEmpty) {
+    stdout.writeln('No annotation issues found.');
+    return;
+  }
+
+  for (final issue in issues) {
+    stderr.writeln(issue);
+  }
+  stderr.writeln('Found ${issues.length} annotation issue(s).');
+  exitCode = 1;
+}

--- a/tools/brick_generator/test/src/annotation_validator_test.dart
+++ b/tools/brick_generator/test/src/annotation_validator_test.dart
@@ -137,11 +137,12 @@ old
     });
 
     group('validateDirectory', () {
-      final tempDir = Directory('./test/_validate_temp_');
+      late Directory tempDir;
 
       setUp(() {
-        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
-        tempDir.createSync(recursive: true);
+        tempDir = Directory.systemTemp.createTempSync(
+          'annotation_validator_',
+        );
       });
 
       tearDown(() {

--- a/tools/brick_generator/test/src/annotation_validator_test.dart
+++ b/tools/brick_generator/test/src/annotation_validator_test.dart
@@ -1,0 +1,182 @@
+import 'dart:io';
+
+import 'package:brick_generator/src/annotation_validator.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  group('AnnotationValidator', () {
+    final validator = AnnotationValidator();
+
+    group('validateContent', () {
+      test('reports no issues for well-formed annotations', () {
+        const content = '''
+line0
+/*remove-start*/
+code
+/*remove-end*/
+/*replace-start*/
+old
+/*with*/
+// new
+/*replace-end*/
+/*insert-start*/
+// inserted
+/*insert-end*/
+/*partial v foo*/payload/*partial ^ foo*/
+''';
+        expect(validator.validateContent(content), isEmpty);
+      });
+
+      test('detects unmatched remove-start', () {
+        const content = '/*remove-start*/\ncode\n';
+        final issues = validator.validateContent(content);
+        expect(issues, hasLength(1));
+        expect(issues.single.line, 1);
+        expect(
+          issues.single.message,
+          contains('Unmatched remove-start'),
+        );
+      });
+
+      test('detects unmatched remove-end', () {
+        const content = 'code\n/*remove-end*/\n';
+        final issues = validator.validateContent(content);
+        expect(issues, hasLength(1));
+        expect(issues.single.line, 2);
+        expect(
+          issues.single.message,
+          contains('Unmatched remove-end'),
+        );
+      });
+
+      test('validates nested remove blocks', () {
+        const content = '''
+/*remove-start*/
+  /*remove-start*/
+  /*remove-end*/
+/*remove-end*/
+''';
+        expect(validator.validateContent(content), isEmpty);
+      });
+
+      test('detects unmatched insert-start', () {
+        const content = '#insert-start#\n';
+        final issues = validator.validateContent(content);
+        expect(issues, hasLength(1));
+        expect(
+          issues.single.message,
+          contains('Unmatched insert-start'),
+        );
+      });
+
+      test('detects replace-end without with', () {
+        const content = '''
+/*replace-start*/
+old
+/*replace-end*/
+''';
+        final issues = validator.validateContent(content);
+        expect(issues, isNotEmpty);
+        expect(
+          issues.map((i) => i.message),
+          anyElement(contains('without a matching with')),
+        );
+      });
+
+      test('detects unmatched replace-start', () {
+        const content = '/*replace-start*/\nold\n';
+        final issues = validator.validateContent(content);
+        expect(issues, isNotEmpty);
+        expect(
+          issues.map((i) => i.message),
+          anyElement(contains('Unmatched replace-start')),
+        );
+      });
+
+      test('accepts replace blocks with with marker', () {
+        const content = '''
+#replace-start#
+old
+#with i1#
+# new
+#replace-end#
+''';
+        expect(validator.validateContent(content), isEmpty);
+      });
+
+      test('detects partial name mismatch', () {
+        const content =
+            '/*partial v foo*/payload/*partial ^ bar*/';
+        final issues = validator.validateContent(content);
+        expect(issues, hasLength(1));
+        expect(
+          issues.single.message,
+          contains('does not match'),
+        );
+      });
+
+      test('detects unmatched partial v', () {
+        const content = '/*partial v foo*/payload';
+        final issues = validator.validateContent(content);
+        expect(issues, hasLength(1));
+        expect(
+          issues.single.message,
+          contains('Unmatched partial v'),
+        );
+      });
+
+      test('validates each comment flavor independently', () {
+        const content = '''
+/*remove-start*/
+#remove-end#
+''';
+        final issues = validator.validateContent(content);
+        expect(issues.length, greaterThanOrEqualTo(2));
+      });
+    });
+
+    group('validateDirectory', () {
+      final tempDir = Directory('./test/_validate_temp_');
+
+      setUp(() {
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+        tempDir.createSync(recursive: true);
+      });
+
+      tearDown(() {
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+      });
+
+      test('walks reference files and attaches paths', () {
+        final validFile = File(p.join(tempDir.path, 'valid.dart'));
+        validFile.createSync(recursive: true);
+        validFile.writeAsStringSync('/*remove-start*/\n/*remove-end*/\n');
+
+        final invalidFile = File(p.join(tempDir.path, 'invalid.dart'));
+        invalidFile.createSync(recursive: true);
+        invalidFile.writeAsStringSync('/*remove-start*/\n');
+
+        final issues = validator.validateDirectory(tempDir);
+        expect(issues, hasLength(1));
+        expect(issues.single.filePath, 'invalid.dart');
+      });
+
+      test('skips binary extensions', () {
+        final image = File(p.join(tempDir.path, 'icon.png'));
+        image.createSync(recursive: true);
+        image.writeAsBytesSync([0, 1, 2]);
+
+        expect(validator.validateDirectory(tempDir), isEmpty);
+      });
+
+      test('skips non-UTF-8 files', () {
+        final binary = File(p.join(tempDir.path, 'notes.txt'));
+        binary.createSync(recursive: true);
+        binary.writeAsBytesSync([0xFF, 0xFE, 0x00]);
+
+        expect(validator.validateDirectory(tempDir), isEmpty);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Overview

Adds a `validate` subcommand to `brick_generator` that walks each brick scope's reference files and checks annotation marker pairing (remove, replace, insert, and partial blocks across all three comment flavors) without running a full generation. Issues are reported with file path, line, and message; the command exits with code 1 when any are found.

Also introduces a `brick.validate` melos script and runs it in the `generate_templates` workflow before `brick.gen`, so broken annotations fail CI early.