### PR TITLE
feat(brick-generator): add single-file preview command

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -617,18 +617,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   melos:
     dependency: "direct dev"
     description:

--- a/tools/brick_generator/lib/main.dart
+++ b/tools/brick_generator/lib/main.dart
@@ -1,22 +1,28 @@
 import 'package:brick_generator/src/generate_brick.dart';
+import 'package:brick_generator/src/preview_options.dart';
+import 'package:brick_generator/src/preview_reference.dart';
 import 'package:brick_generator/src/validate_references.dart';
 
 /// Brick generator CLI.
 ///
 /// Subcommands:
 /// - `validate` — check reference files for annotation errors
+/// - `preview` — transform a single reference file with supplied variables
 /// - default / `gen` — generate the brick template from references
 Future<void> main(List<String> args) async {
   final subcommand = args.firstOrNull ?? 'gen';
+  final subcommandArgs = args.length > 1 ? args.sublist(1) : const <String>[];
   switch (subcommand) {
     case 'validate':
       await validateReferences();
+    case 'preview':
+      await previewReference(PreviewOptions.fromArgs(subcommandArgs));
     case 'gen':
       await generateBrick();
     default:
       throw ArgumentError(
         'Unknown subcommand "$subcommand". '
-        'Supported subcommands: gen, validate.',
+        'Supported subcommands: gen, validate, preview.',
       );
   }
 }

--- a/tools/brick_generator/lib/src/preview_options.dart
+++ b/tools/brick_generator/lib/src/preview_options.dart
@@ -1,0 +1,163 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Parsed CLI options for the `preview` subcommand.
+class PreviewOptions {
+  /// Creates [PreviewOptions].
+  const PreviewOptions({
+    required this.filePath,
+    required this.brickScope,
+    required this.vars,
+    required this.rootPath,
+  });
+
+  /// Parses [args] after the `preview` subcommand name.
+  factory PreviewOptions.fromArgs(List<String> args) {
+    String? filePath;
+    String? brickScope;
+    String? varsRaw;
+    String? rootPath;
+
+    for (var index = 0; index < args.length; index++) {
+      final arg = args[index];
+      switch (arg) {
+        case '--file':
+          filePath = _readValue(args, index, arg);
+          index++;
+        case '--brick':
+          brickScope = _readValue(args, index, arg);
+          index++;
+        case '--vars':
+          varsRaw = _readValue(args, index, arg);
+          index++;
+        case '--root':
+          rootPath = _readValue(args, index, arg);
+          index++;
+        default:
+          throw ArgumentError('Unknown preview argument: $arg');
+      }
+    }
+
+    if (filePath == null || filePath.isEmpty) {
+      throw ArgumentError('Missing required --file <path>.');
+    }
+    if (brickScope == null || brickScope.isEmpty) {
+      throw ArgumentError('Missing required --brick <brick-scope>.');
+    }
+
+    return PreviewOptions(
+      filePath: p.normalize(p.absolute(filePath)),
+      brickScope: brickScope,
+      vars: PreviewVars.parse(varsRaw),
+      rootPath: resolveMonorepoRoot(rootPath),
+    );
+  }
+
+  /// Absolute path to the reference file to preview.
+  final String filePath;
+
+  /// Brick scope identifier (e.g. `altoke_common` or `altoke_common_brick_scope`).
+  final String brickScope;
+
+  /// Mason variable values supplied by the caller.
+  final Map<String, dynamic> vars;
+
+  /// Absolute path to the monorepo root.
+  final String rootPath;
+}
+
+/// Utilities for resolving monorepo and brick-scope paths.
+abstract final class BrickScopePaths {
+  /// Resolves a brick scope directory under [rootPath] from [brickScope].
+  static String scopeDirectory({
+    required String rootPath,
+    required String brickScope,
+  }) {
+    final normalizedScope = brickScope.endsWith('_brick_scope')
+        ? brickScope.substring(0, brickScope.length - '_brick_scope'.length)
+        : brickScope;
+
+    if (p.isWithin(rootPath, normalizedScope) ||
+        p.equals(rootPath, normalizedScope)) {
+      final dir = Directory(normalizedScope);
+      if (dir.existsSync()) return p.normalize(dir.path);
+    }
+
+    final scopeDir = Directory(p.join(rootPath, 'bricks', normalizedScope));
+    if (scopeDir.existsSync()) return p.normalize(scopeDir.path);
+
+    throw ArgumentError(
+      'Brick scope not found for "$brickScope" (looked under ${scopeDir.path}).',
+    );
+  }
+}
+
+/// Resolves the monorepo root from [rootArg], `MELOS_ROOT_PATH`, or [Directory.current].
+String resolveMonorepoRoot(String? rootArg) {
+  if (rootArg != null && rootArg.isNotEmpty) {
+    return p.normalize(p.absolute(rootArg));
+  }
+
+  final melosRoot = Platform.environment['MELOS_ROOT_PATH'];
+  if (melosRoot != null && melosRoot.isNotEmpty) {
+    return p.normalize(melosRoot);
+  }
+
+  var dir = Directory.current;
+  while (true) {
+    final bricksDir = Directory(p.join(dir.path, 'bricks'));
+    final pubspec = File(p.join(dir.path, 'pubspec.yaml'));
+    if (bricksDir.existsSync() && pubspec.existsSync()) {
+      return p.normalize(dir.path);
+    }
+    final parent = dir.parent;
+    if (p.equals(parent.path, dir.path)) break;
+    dir = parent;
+  }
+
+  throw ArgumentError(
+    'Could not resolve monorepo root. Pass --root <path> or set MELOS_ROOT_PATH.',
+  );
+}
+
+/// Parses `key=value` pairs from a comma-separated CLI value.
+abstract final class PreviewVars {
+  /// Parses [raw] into a variable map (empty when null or blank).
+  static Map<String, dynamic> parse(String? raw) {
+    if (raw == null || raw.trim().isEmpty) return {};
+    return {
+      for (final pair in raw.split(','))
+        if (pair.trim().isNotEmpty) ..._parsePair(pair.trim()),
+    };
+  }
+
+  static Map<String, dynamic> _parsePair(String pair) {
+    final separatorIndex = pair.indexOf('=');
+    if (separatorIndex <= 0) {
+      throw ArgumentError('Invalid --vars entry (expected key=value): $pair');
+    }
+    final key = pair.substring(0, separatorIndex).trim();
+    final rawValue = pair.substring(separatorIndex + 1).trim();
+    return {key: _parseValue(rawValue)};
+  }
+
+  static dynamic _parseValue(String rawValue) {
+    if (rawValue == 'true') return true;
+    if (rawValue == 'false') return false;
+    final intValue = int.tryParse(rawValue);
+    if (intValue != null) return intValue;
+    if ((rawValue.startsWith('"') && rawValue.endsWith('"')) ||
+        (rawValue.startsWith("'") && rawValue.endsWith("'"))) {
+      return rawValue.substring(1, rawValue.length - 1);
+    }
+    return rawValue;
+  }
+}
+
+String _readValue(List<String> args, int index, String flag) {
+  if (index + 1 >= args.length) {
+    throw ArgumentError('Missing value for $flag.');
+  }
+  return args[index + 1];
+}

--- a/tools/brick_generator/lib/src/preview_reference.dart
+++ b/tools/brick_generator/lib/src/preview_reference.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:brick_generator/src/models/brick_gen_data.dart';
+import 'package:brick_generator/src/models/brick_gen_options.dart';
+import 'package:brick_generator/src/preview_options.dart';
+import 'package:brick_generator/src/resolve_reference_content.dart';
+import 'package:mason/mason.dart';
+import 'package:path/path.dart' as p;
+
+/// Transforms a single reference file and writes the result via [write]
+/// (stdout by default).
+Future<void> previewReference(
+  PreviewOptions options, {
+  void Function(String content)? write,
+}) async {
+  final emit = write ?? stdout.write;
+  final file = File(options.filePath);
+  if (!file.existsSync()) {
+    throw ArgumentError('File not found: ${options.filePath}');
+  }
+
+  final scopeDir = BrickScopePaths.scopeDirectory(
+    rootPath: options.rootPath,
+    brickScope: options.brickScope,
+  );
+  final referenceDir = Directory(p.join(scopeDir, 'reference'));
+  if (!referenceDir.existsSync()) {
+    throw ArgumentError('Reference directory not found: ${referenceDir.path}');
+  }
+
+  final referencePath = p.normalize(file.absolute.path);
+  if (!p.isWithin(referenceDir.path, referencePath)) {
+    throw ArgumentError(
+      'File must be under the reference directory (${referenceDir.path}).',
+    );
+  }
+
+  final brickGenDataFile = File(p.join(scopeDir, 'brick-gen.json'));
+  if (!brickGenDataFile.existsSync()) {
+    throw ArgumentError('brick-gen.json not found in $scopeDir');
+  }
+
+  final brickGenOptions = BrickGenOptions.fromJson(
+    jsonDecode(await brickGenDataFile.readAsString()) as Map<String, dynamic>,
+  );
+
+  final tempTargetDir = await Directory.systemTemp.createTemp(
+    'brick_generator_preview_',
+  );
+  try {
+    final referenceRelativePath = p.relative(referencePath, from: referenceDir.path);
+    final simulatedTargetPath = p.join(
+      tempTargetDir.path,
+      referenceRelativePath,
+    );
+    final brickGenData = BrickGenData.fromOptions(
+      referenceAbsolutePath: referenceDir.path,
+      targetAbsolutePath: tempTargetDir.path,
+      options: brickGenOptions,
+    );
+
+    final resolvedTargetPath = brickGenData.applyReplacementsToTargetRelativeDescendant(
+      simulatedTargetPath,
+    );
+    final targetRelativePath = p.relative(
+      resolvedTargetPath,
+      from: tempTargetDir.path,
+    );
+
+    final annotatedContent = resolveReferenceContent(
+      content: await file.readAsString(),
+      targetRelativePath: targetRelativePath,
+      brickGenData: brickGenData,
+    );
+
+    final partials = _loadPartials(tempTargetDir);
+    final rendered = annotatedContent.render(options.vars, partials);
+    emit(rendered);
+  } finally {
+    await tempTargetDir.delete(recursive: true);
+  }
+}
+
+Map<String, List<int>> _loadPartials(Directory targetDir) {
+  if (!targetDir.existsSync()) return {};
+  final partials = <String, List<int>>{};
+  for (final entity in targetDir.listSync(recursive: true)) {
+    if (entity is! File) continue;
+    final name = p.basename(entity.path);
+    if (!name.startsWith('{{~ ') || !name.endsWith(' }}')) continue;
+    partials[name] = utf8.encode(entity.readAsStringSync());
+  }
+  return partials;
+}

--- a/tools/brick_generator/lib/src/reference_content_transforms.dart
+++ b/tools/brick_generator/lib/src/reference_content_transforms.dart
@@ -1,0 +1,172 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Annotation-marker transforms applied to reference file contents.
+extension ReferenceContentTransforms on String {
+  String get withResolvedRemotions {
+    final blockDropPatterns = [r'\/\*drop\*\/.*', '#drop#.*', '<!--drop-->.*'];
+    final blockDropPattern = blockDropPatterns
+        .map((pattern) => '(?:$pattern)')
+        .join('|');
+    final blockDropRegex = RegExp(blockDropPattern, dotAll: true);
+    final afterDropContent = replaceAll(blockDropRegex, '');
+    final blockRemotionPatterns = [
+      r'(?<leading>\s*)\/\*(?<dropLeading>x-)?remove-start\*\/.*?\/\*remove-end(?<dropTrailing>-x)?\*\/(?<trailing>\s*)',
+      r'(?<leading>\s*)#(?<dropLeading>x-)?remove-start#.*?#remove-end(?<dropTrailing>-x)?#(?<trailing>\s*)',
+      r'(?<leading>\s*)<!--(?<dropLeading>x-)?remove-start-->.*?<!--remove-end(?<dropTrailing>-x)?-->(?<trailing>\s*)',
+    ];
+    return blockRemotionPatterns.fold(afterDropContent, (content, pattern) {
+      final regex = RegExp(pattern, dotAll: true);
+      return content.replaceAllMapped(regex, (match) {
+        match as RegExpMatch;
+        final keepLeading = (match.namedGroup('dropLeading') ?? '').isEmpty;
+        final keepTrailing = (match.namedGroup('dropTrailing') ?? '').isEmpty;
+        final leading = match.namedGroup('leading') ?? '';
+        final trailing = match.namedGroup('trailing') ?? '';
+        return [if (keepLeading) leading, if (keepTrailing) trailing].join();
+      });
+    });
+  }
+
+  String get withResolveReplacements {
+    final patternGroups = [
+      (
+        r'\/\*replace-start\*\/ *\n*.*?\n* *\/\*with(?: +i(?<indentation>\d+))?\*\/ *\n(?<replacement>.*?)\n *\/\*replace-end\*\/',
+        r'\/\/ (?<line>.*)',
+      ),
+      (
+        r'#replace-start# *\n*.*?\n* *#with(?: +i(?<indentation>\d+))?# *\n(?<replacement>.*?)\n *#replace-end#',
+        '# (?<line>.*)',
+      ),
+      (
+        r'<!--replace-start--> *\n*.*?\n* *<!--with(?: +i(?<indentation>\d+))?--> *\n(?<replacement>.*?)\n *<!--replace-end-->',
+        '<!-- (?<line>.*)-->',
+      ),
+    ];
+    return patternGroups.fold(this, (content, patternGroup) {
+      final (replacementPattern, linePattern) = patternGroup;
+      final replacementRegex = RegExp(replacementPattern, dotAll: true);
+      final lineRegex = RegExp(linePattern, dotAll: true);
+      return content.replaceAllMapped(replacementRegex, (match) {
+        match as RegExpMatch;
+        final indentation =
+            int.tryParse(match.namedGroup('indentation') ?? '') ?? 0;
+        final replacement = match.namedGroup('replacement') ?? '';
+        final lines = LineSplitter.split(replacement);
+        return lines
+            .map((line) {
+              final lineMatch = lineRegex.allMatches(line).single;
+              final lineContent = lineMatch.namedGroup('line') ?? '';
+              return ' ' * indentation + lineContent;
+            })
+            .join('\n');
+      });
+    });
+  }
+
+  String get withResolvedInsertions {
+    final patternGroups = [
+      (
+        r'\/\*insert-start\*\/ *\n(?<insertion>.*?)\n *\/\*insert-end\*\/',
+        r'\/\/ (?<line>.*)',
+      ),
+      (r'#insert-start# *\n(?<insertion>.*?)\n *#insert-end#', '# (?<line>.*)'),
+      (
+        r'<!--insert-start--> *\n(?<insertion>.*?)\n *<!--insert-end-->',
+        '<!-- (?<line>.*)-->',
+      ),
+    ];
+    return patternGroups.fold(this, (content, patternGroup) {
+      final (insertionPattern, linePattern) = patternGroup;
+      final insertionRegex = RegExp(insertionPattern, dotAll: true);
+      final lineRegex = RegExp(linePattern, dotAll: true);
+      return content.replaceAllMapped(insertionRegex, (match) {
+        match as RegExpMatch;
+        final insertion = match.namedGroup('insertion') ?? '';
+        final lines = LineSplitter.split(insertion);
+        return lines
+            .map((line) {
+              final lineMatch = lineRegex.allMatches(line).single;
+              final lineContent = lineMatch.namedGroup('line') ?? '';
+              return lineContent;
+            })
+            .join('\n');
+      });
+    });
+  }
+
+  String get withResolveMustacheTags {
+    final patterns = [
+      r'(?<leading>\s*)\/\*(?<dropLeading>x)?(?<mustacheTag>{{.*?}})(?<dropTrailing>x)?\*\/(?<trailing>\s*)',
+      r'(?<leading>\s*)#(?<dropLeading>x)?(?<mustacheTag>{{.*?}})(?<dropTrailing>x)?#(?<trailing>\s*)',
+      r'(?<leading>\s*)<!--(?<dropLeading>x)?(?<mustacheTag>{{.*?}})(?<dropTrailing>x)?-->(?<trailing>\s*)',
+    ];
+    return patterns.fold(this, (content, pattern) {
+      final regex = RegExp(pattern, dotAll: true);
+      return content.replaceAllMapped(regex, (match) {
+        match as RegExpMatch;
+        final mustacheTag = match.namedGroup('mustacheTag') ?? '';
+        final keepLeading = (match.namedGroup('dropLeading') ?? '').isEmpty;
+        final keepTrailing = (match.namedGroup('dropTrailing') ?? '').isEmpty;
+        final leading = match.namedGroup('leading') ?? '';
+        final trailing = match.namedGroup('trailing') ?? '';
+        return [
+          if (keepLeading) leading,
+          mustacheTag,
+          if (keepTrailing) trailing,
+        ].join();
+      });
+    });
+  }
+
+  String get withResolveSpacingGroups {
+    const groupPatterns = [
+      r'\s*\/\*w ?(?<spacingGroups>(?:\d+[v>] ?)*) ?w\*\/\s*',
+      r'\s*#w ?(?<spacingGroups>(?:\d+[v>] ?)*) ?w#\s*',
+      r'\s*<!--w ?(?<spacingGroups>(?:\d+[v>] ?)*) ?w-->\s*',
+    ];
+    const actionPattern = r'(?<actionTimes>\d+)(?<actionType>[v>]) ?';
+    return groupPatterns.fold(this, (content, groupPattern) {
+      final groupRegex = RegExp(groupPattern, dotAll: true);
+      final actionRegex = RegExp(actionPattern, dotAll: true);
+      return content.replaceAllMapped(groupRegex, (match) {
+        match as RegExpMatch;
+        final spacingGroups = match.namedGroup('spacingGroups') ?? '';
+        return spacingGroups.replaceAllMapped(actionRegex, (actionMatch) {
+          actionMatch as RegExpMatch;
+          final actionTimes =
+              int.tryParse(actionMatch.namedGroup('actionTimes') ?? '') ?? 0;
+          final actionType = actionMatch.namedGroup('actionType') ?? '';
+          return switch (actionType) {
+                'v' => '\n',
+                '>' => ' ',
+                _ => '',
+              } *
+              actionTimes;
+        });
+      });
+    });
+  }
+
+  String withResolvedPartials({required String targetAbsolutePath}) {
+    final partialPatterns = [
+      r'\/\*partial v (?<partialName>.*?)\*\/(?<partialPayload>.*?)\/\*partial \^ \k<partialName>\*\/',
+      r'#partial v (?<partialName>.*?)#(?<partialPayload>.*?)#partial \^ \k<partialName>#',
+      r'<!--partial v (?<partialName>.*?)-->(?<partialPayload>.*?)<!--partial \^ \k<partialName>-->',
+    ];
+    return partialPatterns.fold(this, (content, pattern) {
+      final regex = RegExp(pattern, dotAll: true);
+      return content.replaceAllMapped(regex, (match) {
+        match as RegExpMatch;
+        final partialName = match.namedGroup('partialName') ?? '';
+        final partialPayload = match.namedGroup('partialPayload') ?? '';
+        File(p.join(targetAbsolutePath, '{{~ $partialName.partial }}'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync(partialPayload);
+        return '{{> $partialName.partial }}';
+      });
+    });
+  }
+}

--- a/tools/brick_generator/lib/src/reference_file.dart
+++ b/tools/brick_generator/lib/src/reference_file.dart
@@ -1,177 +1,10 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:brick_generator/src/models/models.dart';
+import 'package:brick_generator/src/resolve_reference_content.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:shell/git.dart';
-
-extension on String {
-  String get withResolvedRemotions {
-    final blockDropPatterns = [r'\/\*drop\*\/.*', '#drop#.*', '<!--drop-->.*'];
-    final blockDropPattern = blockDropPatterns
-        .map((pattern) => '(?:$pattern)')
-        .join('|');
-    final blockDropRegex = RegExp(blockDropPattern, dotAll: true);
-    final afterDropContent = replaceAll(blockDropRegex, '');
-    final blockRemotionPatterns = [
-      r'(?<leading>\s*)\/\*(?<dropLeading>x-)?remove-start\*\/.*?\/\*remove-end(?<dropTrailing>-x)?\*\/(?<trailing>\s*)',
-      r'(?<leading>\s*)#(?<dropLeading>x-)?remove-start#.*?#remove-end(?<dropTrailing>-x)?#(?<trailing>\s*)',
-      r'(?<leading>\s*)<!--(?<dropLeading>x-)?remove-start-->.*?<!--remove-end(?<dropTrailing>-x)?-->(?<trailing>\s*)',
-    ];
-    return blockRemotionPatterns.fold(afterDropContent, (content, pattern) {
-      final regex = RegExp(pattern, dotAll: true);
-      return content.replaceAllMapped(regex, (match) {
-        match as RegExpMatch;
-        final keepLeading = (match.namedGroup('dropLeading') ?? '').isEmpty;
-        final keepTrailing = (match.namedGroup('dropTrailing') ?? '').isEmpty;
-        final leading = match.namedGroup('leading') ?? '';
-        final trailing = match.namedGroup('trailing') ?? '';
-        return [if (keepLeading) leading, if (keepTrailing) trailing].join();
-      });
-    });
-  }
-
-  String get withResolveReplacements {
-    final patternGroups = [
-      (
-        r'\/\*replace-start\*\/ *\n*.*?\n* *\/\*with(?: +i(?<indentation>\d+))?\*\/ *\n(?<replacement>.*?)\n *\/\*replace-end\*\/',
-        r'\/\/ (?<line>.*)',
-      ),
-      (
-        r'#replace-start# *\n*.*?\n* *#with(?: +i(?<indentation>\d+))?# *\n(?<replacement>.*?)\n *#replace-end#',
-        '# (?<line>.*)',
-      ),
-      (
-        r'<!--replace-start--> *\n*.*?\n* *<!--with(?: +i(?<indentation>\d+))?--> *\n(?<replacement>.*?)\n *<!--replace-end-->',
-        '<!-- (?<line>.*)-->',
-      ),
-    ];
-    return patternGroups.fold(this, (content, patternGroup) {
-      final (replacementPattern, linePattern) = patternGroup;
-      final replacementRegex = RegExp(replacementPattern, dotAll: true);
-      final lineRegex = RegExp(linePattern, dotAll: true);
-      return content.replaceAllMapped(replacementRegex, (match) {
-        match as RegExpMatch;
-        final indentation =
-            int.tryParse(match.namedGroup('indentation') ?? '') ?? 0;
-        final replacement = match.namedGroup('replacement') ?? '';
-        final lines = LineSplitter.split(replacement);
-        return lines
-            .map((line) {
-              final lineMatch = lineRegex.allMatches(line).single;
-              final lineContent = lineMatch.namedGroup('line') ?? '';
-              return ' ' * indentation + lineContent;
-            })
-            .join('\n');
-      });
-    });
-  }
-
-  String get withResolvedInsertions {
-    final patternGroups = [
-      (
-        r'\/\*insert-start\*\/ *\n(?<insertion>.*?)\n *\/\*insert-end\*\/',
-        r'\/\/ (?<line>.*)',
-      ),
-      (r'#insert-start# *\n(?<insertion>.*?)\n *#insert-end#', '# (?<line>.*)'),
-      (
-        r'<!--insert-start--> *\n(?<insertion>.*?)\n *<!--insert-end-->',
-        '<!-- (?<line>.*)-->',
-      ),
-    ];
-    return patternGroups.fold(this, (content, patternGroup) {
-      final (insertionPattern, linePattern) = patternGroup;
-      final insertionRegex = RegExp(insertionPattern, dotAll: true);
-      final lineRegex = RegExp(linePattern, dotAll: true);
-      return content.replaceAllMapped(insertionRegex, (match) {
-        match as RegExpMatch;
-        final insertion = match.namedGroup('insertion') ?? '';
-        final lines = LineSplitter.split(insertion);
-        return lines
-            .map((line) {
-              final lineMatch = lineRegex.allMatches(line).single;
-              final lineContent = lineMatch.namedGroup('line') ?? '';
-              return lineContent;
-            })
-            .join('\n');
-      });
-    });
-  }
-
-  String get withResolveMustacheTags {
-    final patterns = [
-      r'(?<leading>\s*)\/\*(?<dropLeading>x)?(?<mustacheTag>{{.*?}})(?<dropTrailing>x)?\*\/(?<trailing>\s*)',
-      r'(?<leading>\s*)#(?<dropLeading>x)?(?<mustacheTag>{{.*?}})(?<dropTrailing>x)?#(?<trailing>\s*)',
-      r'(?<leading>\s*)<!--(?<dropLeading>x)?(?<mustacheTag>{{.*?}})(?<dropTrailing>x)?-->(?<trailing>\s*)',
-    ];
-    return patterns.fold(this, (content, pattern) {
-      final regex = RegExp(pattern, dotAll: true);
-      return content.replaceAllMapped(regex, (match) {
-        match as RegExpMatch;
-        final mustacheTag = match.namedGroup('mustacheTag') ?? '';
-        final keepLeading = (match.namedGroup('dropLeading') ?? '').isEmpty;
-        final keepTrailing = (match.namedGroup('dropTrailing') ?? '').isEmpty;
-        final leading = match.namedGroup('leading') ?? '';
-        final trailing = match.namedGroup('trailing') ?? '';
-        return [
-          if (keepLeading) leading,
-          mustacheTag,
-          if (keepTrailing) trailing,
-        ].join();
-      });
-    });
-  }
-
-  String get withResolveSpacingGroups {
-    const groupPatterns = [
-      r'\s*\/\*w ?(?<spacingGroups>(?:\d+[v>] ?)*) ?w\*\/\s*',
-      r'\s*#w ?(?<spacingGroups>(?:\d+[v>] ?)*) ?w#\s*',
-      r'\s*<!--w ?(?<spacingGroups>(?:\d+[v>] ?)*) ?w-->\s*',
-    ];
-    const actionPattern = r'(?<actionTimes>\d+)(?<actionType>[v>]) ?';
-    return groupPatterns.fold(this, (content, groupPattern) {
-      final groupRegex = RegExp(groupPattern, dotAll: true);
-      final actionRegex = RegExp(actionPattern, dotAll: true);
-      return content.replaceAllMapped(groupRegex, (match) {
-        match as RegExpMatch;
-        final spacingGroups = match.namedGroup('spacingGroups') ?? '';
-        return spacingGroups.replaceAllMapped(actionRegex, (actionMatch) {
-          actionMatch as RegExpMatch;
-          final actionTimes =
-              int.tryParse(actionMatch.namedGroup('actionTimes') ?? '') ?? 0;
-          final actionType = actionMatch.namedGroup('actionType') ?? '';
-          return switch (actionType) {
-                'v' => '\n',
-                '>' => ' ',
-                _ => '',
-              } *
-              actionTimes;
-        });
-      });
-    });
-  }
-
-  String withResolvedPartials({required String targetAbsolutePath}) {
-    final partialPatterns = [
-      r'\/\*partial v (?<partialName>.*?)\*\/(?<partialPayload>.*?)\/\*partial \^ \k<partialName>\*\/',
-      r'#partial v (?<partialName>.*?)#(?<partialPayload>.*?)#partial \^ \k<partialName>#',
-      r'<!--partial v (?<partialName>.*?)-->(?<partialPayload>.*?)<!--partial \^ \k<partialName>-->',
-    ];
-    return partialPatterns.fold(this, (content, pattern) {
-      final regex = RegExp(pattern, dotAll: true);
-      return content.replaceAllMapped(regex, (match) {
-        match as RegExpMatch;
-        final partialName = match.namedGroup('partialName') ?? '';
-        final partialPayload = match.namedGroup('partialPayload') ?? '';
-        File(p.join(targetAbsolutePath, '{{~ $partialName.partial }}'))
-          ..createSync(recursive: true)
-          ..writeAsStringSync(partialPayload);
-        return '{{> $partialName.partial }}';
-      });
-    });
-  }
-}
 
 /// Extension methods for a reference [File] to be parametrized.
 extension ReferenceFile on File {
@@ -209,22 +42,15 @@ extension ReferenceFile on File {
       '.webp', // cspell:disable-line
     };
     if (ignoredExtensions.contains(p.extension(path))) return;
-    final BrickGenData(:replacements, :lineDeletions) = brickGenData;
     final referenceContent = await readAsString();
-    final resolvedContents = referenceContent
-        .applyLineDeletions(
-          filePath: p.relative(path, from: brickGenData.targetAbsolutePath),
-          lineDeletions: lineDeletions,
-        )
-        .applyReplacements(replacements)
-        .withResolvedRemotions
-        .withResolveReplacements
-        .withResolvedInsertions
-        .withResolveMustacheTags
-        .withResolveSpacingGroups
-        .withResolvedPartials(
-          targetAbsolutePath: brickGenData.targetAbsolutePath,
-        );
+    final resolvedContents = resolveReferenceContent(
+      content: referenceContent,
+      targetRelativePath: p.relative(
+        path,
+        from: brickGenData.targetAbsolutePath,
+      ),
+      brickGenData: brickGenData,
+    );
     await writeAsString(resolvedContents);
   }
 

--- a/tools/brick_generator/lib/src/resolve_reference_content.dart
+++ b/tools/brick_generator/lib/src/resolve_reference_content.dart
@@ -1,0 +1,26 @@
+import 'package:brick_generator/src/models/models.dart';
+import 'package:brick_generator/src/reference_content_transforms.dart';
+
+/// Applies the brick-generator annotation and [brickGenData] transforms to
+/// [content] as if it lived at [targetRelativePath] under [brickGenData]'s
+/// target directory.
+String resolveReferenceContent({
+  required String content,
+  required String targetRelativePath,
+  required BrickGenData brickGenData,
+}) {
+  final BrickGenData(:replacements, :lineDeletions, :targetAbsolutePath) =
+      brickGenData;
+  return content
+      .applyLineDeletions(
+        filePath: targetRelativePath,
+        lineDeletions: lineDeletions,
+      )
+      .applyReplacements(replacements)
+      .withResolvedRemotions
+      .withResolveReplacements
+      .withResolvedInsertions
+      .withResolveMustacheTags
+      .withResolveSpacingGroups
+      .withResolvedPartials(targetAbsolutePath: targetAbsolutePath);
+}

--- a/tools/brick_generator/pubspec.yaml
+++ b/tools/brick_generator/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   dart_mappable: ^4.6.1
+  mason: ^0.1.2
   meta: ^1.17.0
   monorepo_elements:
     path: ../monorepo_elements

--- a/tools/brick_generator/test/src/preview_options_test.dart
+++ b/tools/brick_generator/test/src/preview_options_test.dart
@@ -1,0 +1,35 @@
+import 'package:brick_generator/src/preview_options.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PreviewVars', () {
+    test('parses booleans, numbers, and strings', () {
+      expect(
+        PreviewVars.parse('requirements_met=true,use_drift=false,count=3,name=app'),
+        {
+          'requirements_met': true,
+          'use_drift': false,
+          'count': 3,
+          'name': 'app',
+        },
+      );
+    });
+
+    test('returns empty map for null input', () {
+      expect(PreviewVars.parse(null), isEmpty);
+    });
+
+    test('throws for invalid pairs', () {
+      expect(() => PreviewVars.parse('not-a-pair'), throwsArgumentError);
+    });
+  });
+
+  group('PreviewOptions.fromArgs', () {
+    test('requires --file and --brick', () {
+      expect(
+        () => PreviewOptions.fromArgs(['--file', 'a.txt']),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/tools/brick_generator/test/src/preview_reference_test.dart
+++ b/tools/brick_generator/test/src/preview_reference_test.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+
+import 'package:brick_generator/src/preview_options.dart';
+import 'package:brick_generator/src/preview_reference.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  group('previewReference', () {
+    late Directory tempDir;
+    late String rootPath;
+    late String referenceFilePath;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('brick_preview_test_');
+      rootPath = tempDir.path;
+
+      final scopeDir = Directory(p.join(rootPath, 'bricks', 'sample'));
+      final referenceDir = Directory(p.join(scopeDir.path, 'reference'))
+        ..createSync(recursive: true);
+      await File(p.join(scopeDir.path, 'brick-gen.json')).writeAsString('''
+{
+  "replacements": [
+    {
+      "from": "Widget",
+      "to": "{{#use_riverpod}}ConsumerWidget{{/use_riverpod}}{{^use_riverpod}}StatelessWidget{{/use_riverpod}}"
+    }
+  ]
+}
+''');
+
+      referenceFilePath = p.join(referenceDir.path, 'widget.dart');
+      await File(referenceFilePath).writeAsString('''
+class App extends Widget {
+  /*remove-start*/
+  // scaffold
+  /*remove-end*/
+}
+''');
+    });
+
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test('writes transformed content to the output sink', () async {
+      final output = StringBuffer();
+      await previewReference(
+        PreviewOptions(
+          filePath: referenceFilePath,
+          brickScope: 'sample',
+          vars: PreviewVars.parse('use_riverpod=true'),
+          rootPath: rootPath,
+        ),
+        write: output.write,
+      );
+
+      final result = output.toString();
+      expect(result, contains('class App extends ConsumerWidget'));
+      expect(result, isNot(contains('remove-start')));
+      expect(result, isNot(contains('scaffold')));
+    });
+
+    test('selects the stateless branch when use_riverpod is false', () async {
+      final output = StringBuffer();
+      await previewReference(
+        PreviewOptions(
+          filePath: referenceFilePath,
+          brickScope: 'sample',
+          vars: PreviewVars.parse('use_riverpod=false'),
+          rootPath: rootPath,
+        ),
+        write: output.write,
+      );
+
+      expect(output.toString(), contains('class App extends StatelessWidget'));
+    });
+  });
+}

--- a/tools/brick_generator/test/src/resolve_reference_content_test.dart
+++ b/tools/brick_generator/test/src/resolve_reference_content_test.dart
@@ -1,0 +1,49 @@
+import 'package:brick_generator/src/models/brick_gen_data.dart';
+import 'package:brick_generator/src/resolve_reference_content.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('resolveReferenceContent', () {
+    test('removes a remove-start/end block', () {
+      const input = '''
+line0
+/*remove-start*/
+scaffold
+/*remove-end*/
+line1
+''';
+      const expected = '''
+line0
+
+line1
+''';
+      final result = resolveReferenceContent(
+        content: input,
+        targetRelativePath: 'file.txt',
+        brickGenData: const BrickGenData(
+          referenceAbsolutePath: '',
+          targetAbsolutePath: '.',
+          replacements: [],
+          lineDeletions: [],
+        ),
+      );
+      expect(result, expected);
+    });
+
+    test('unwraps a commented mustache tag', () {
+      const input = '/*x{{flag}}*/tail';
+      const expected = '{{flag}}tail';
+      final result = resolveReferenceContent(
+        content: input,
+        targetRelativePath: 'file.txt',
+        brickGenData: const BrickGenData(
+          referenceAbsolutePath: '',
+          targetAbsolutePath: '.',
+          replacements: [],
+          lineDeletions: [],
+        ),
+      );
+      expect(result, expected);
+    });
+  });
+}


### PR DESCRIPTION
## Overview

Adds a `preview` subcommand to `brick_generator` that transforms a single reference file with caller-supplied Mason variables and writes the result to stdout. The command applies the same annotation-resolution pipeline and `brick-gen.json` replacements used during full generation, then renders Mustache with the provided `--vars` so tools (such as a future VS Code extension) can show generated output for one file without running `brick.gen`.