### PR TITLE
feat(vscode-ext): add configurable annotation highlighting

### DIFF
--- a/tools/vscode_extension/README.md
+++ b/tools/vscode_extension/README.md
@@ -2,7 +2,7 @@
 
 Editor support for [brick generator](https://github.com/mrverdant13/altoke_bricks/tree/main/tools/brick_generator) annotation syntax in reference projects.
 
-This package is a scaffold: syntax highlighting, folding, diagnostics, and inline preview land in follow-up changes.
+Syntax highlighting for brick annotation markers is active in `.dart`, `.sh`, `.yaml`, `.html`, and `.xml` reference files. Folding, diagnostics, and inline preview land in follow-up changes.
 
 ## Prerequisites
 

--- a/tools/vscode_extension/README.md
+++ b/tools/vscode_extension/README.md
@@ -2,7 +2,49 @@
 
 Editor support for [brick generator](https://github.com/mrverdant13/altoke_bricks/tree/main/tools/brick_generator) annotation syntax in reference projects.
 
-Syntax highlighting for brick annotation markers is active in `.dart`, `.sh`, `.yaml`, `.html`, and `.xml` reference files. Folding, diagnostics, and inline preview land in follow-up changes.
+The extension now provides annotation-aware highlighting for all currently supported marker types, including range shading for block annotations.
+
+## Current capabilities
+
+- Marker highlighting for: `remove-start/end`, `drop`, `replace-start/with/end`, `insert-start/end`, `partial v/^`, Mustache tags (`{{...}}`) inside comment annotations, and spacing directives (`w ... w`)
+- Block/range shading for: remove blocks, drop tails, replace original/replacement segments, insert blocks, and partial payload blocks
+- Coverage across reference file types used in this monorepo, including `.dart`, `.sh`, `.yaml`, `.yml`, `.html`, `.xml`, `.md`, and ignore-style files such as `.gitignore`
+- Theme-friendly TextMate scopes with extension-provided defaults for both dark and light themes
+
+Folding, diagnostics, and inline preview land in follow-up changes.
+
+## Customizing annotation colors
+
+All annotation colors are configurable in VS Code settings under `brickGenerator.colors.*`.
+
+Example:
+
+```json
+{
+  "brickGenerator.colors.remove.markerForeground": "#ff6b6b",
+  "brickGenerator.colors.remove.contentBackground": "rgba(255, 107, 107, 0.18)",
+  "brickGenerator.colors.replace.withMarkerForeground": "#43c6ac",
+  "brickGenerator.colors.mustache.tagForeground": "#c77dff"
+}
+```
+
+Available keys:
+
+- `brickGenerator.colors.remove.markerForeground`
+- `brickGenerator.colors.remove.contentBackground`
+- `brickGenerator.colors.replace.boundaryMarkerForeground`
+- `brickGenerator.colors.replace.withMarkerForeground`
+- `brickGenerator.colors.replace.originalBackground`
+- `brickGenerator.colors.replace.replacementBackground`
+- `brickGenerator.colors.insert.markerForeground`
+- `brickGenerator.colors.insert.contentBackground`
+- `brickGenerator.colors.partial.markerForeground`
+- `brickGenerator.colors.partial.payloadBackground`
+- `brickGenerator.colors.mustache.tagForeground`
+- `brickGenerator.colors.mustache.commentBackground`
+- `brickGenerator.colors.mustache.dropFlagForeground`
+- `brickGenerator.colors.spacing.markerForeground`
+- `brickGenerator.colors.spacing.markerBackground`
 
 ## Prerequisites
 

--- a/tools/vscode_extension/package.json
+++ b/tools/vscode_extension/package.json
@@ -21,7 +21,21 @@
     "onStartupFinished"
   ],
   "main": "./out/extension.js",
-  "contributes": {},
+  "contributes": {
+    "grammars": [
+      {
+        "scopeName": "brick-generator.injection",
+        "path": "./syntaxes/brick-generator.tmLanguage.json",
+        "injectTo": [
+          "source.dart",
+          "source.shell",
+          "source.yaml",
+          "text.html",
+          "text.xml"
+        ]
+      }
+    ]
+  },
   "scripts": {
     "compile": "node esbuild.mjs",
     "watch": "node esbuild.mjs --watch",

--- a/tools/vscode_extension/package.json
+++ b/tools/vscode_extension/package.json
@@ -22,6 +22,210 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "configurationDefaults": {
+      "editor.tokenColorCustomizations": {
+        "textMateRules": [
+          {
+            "scope": [
+              "keyword.annotation.brick-generator.remove",
+              "keyword.annotation.brick-generator.drop",
+              "constant.language.brick-generator.drop-flag"
+            ],
+            "settings": {
+              "foreground": "#F48771",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "keyword.annotation.brick-generator.replace.boundary",
+            "settings": {
+              "foreground": "#E5A84B",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "keyword.annotation.brick-generator.replace.with",
+            "settings": {
+              "foreground": "#4EC9B0",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "keyword.annotation.brick-generator.insert",
+            "settings": {
+              "foreground": "#C586C0",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": [
+              "keyword.annotation.brick-generator.partial",
+              "keyword.annotation.brick-generator.partial.marker"
+            ],
+            "settings": {
+              "foreground": "#569CD6",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "entity.name.tag.mustache.brick-generator",
+            "settings": {
+              "foreground": "#C678DD",
+              "fontStyle": "bold"
+            }
+          },
+          {
+            "scope": "meta.annotation.brick-generator.spacing",
+            "settings": {
+              "foreground": "#A0A1A7",
+              "fontStyle": "bold"
+            }
+          }
+        ]
+      },
+      "[Default Light+]": {
+        "editor.tokenColorCustomizations": {
+          "textMateRules": [
+            {
+              "scope": [
+                "keyword.annotation.brick-generator.remove",
+                "keyword.annotation.brick-generator.drop",
+                "constant.language.brick-generator.drop-flag"
+              ],
+              "settings": {
+                "foreground": "#D16969",
+                "fontStyle": "bold"
+              }
+            },
+            {
+              "scope": "keyword.annotation.brick-generator.replace.boundary",
+              "settings": {
+                "foreground": "#B8890B",
+                "fontStyle": "bold"
+              }
+            },
+            {
+              "scope": "keyword.annotation.brick-generator.replace.with",
+              "settings": {
+                "foreground": "#098658",
+                "fontStyle": "bold"
+              }
+            },
+            {
+              "scope": "keyword.annotation.brick-generator.insert",
+              "settings": {
+                "foreground": "#A626A4",
+                "fontStyle": "bold"
+              }
+            },
+            {
+              "scope": [
+                "keyword.annotation.brick-generator.partial",
+                "keyword.annotation.brick-generator.partial.marker"
+              ],
+              "settings": {
+                "foreground": "#0451A5",
+                "fontStyle": "bold"
+              }
+            },
+            {
+              "scope": "entity.name.tag.mustache.brick-generator",
+              "settings": {
+                "foreground": "#AF00DB",
+                "fontStyle": "bold"
+              }
+            },
+            {
+              "scope": "meta.annotation.brick-generator.spacing",
+              "settings": {
+                "foreground": "#6A737D",
+                "fontStyle": "bold"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "configuration": {
+      "title": "Brick Generator",
+      "properties": {
+        "brickGenerator.colors.remove.markerForeground": {
+          "type": "string",
+          "default": "#F48771",
+          "description": "Foreground color for remove-start / remove-end / drop markers."
+        },
+        "brickGenerator.colors.remove.contentBackground": {
+          "type": "string",
+          "default": "rgba(244, 135, 113, 0.14)",
+          "description": "Background color for content inside remove blocks and after drop markers."
+        },
+        "brickGenerator.colors.replace.boundaryMarkerForeground": {
+          "type": "string",
+          "default": "#E5A84B",
+          "description": "Foreground color for replace-start / replace-end markers."
+        },
+        "brickGenerator.colors.replace.withMarkerForeground": {
+          "type": "string",
+          "default": "#4EC9B0",
+          "description": "Foreground color for the with marker inside replace blocks."
+        },
+        "brickGenerator.colors.replace.originalBackground": {
+          "type": "string",
+          "default": "rgba(229, 168, 75, 0.14)",
+          "description": "Background color for the original (scaffold) section inside replace blocks."
+        },
+        "brickGenerator.colors.replace.replacementBackground": {
+          "type": "string",
+          "default": "rgba(78, 201, 176, 0.14)",
+          "description": "Background color for the replacement section inside replace blocks."
+        },
+        "brickGenerator.colors.insert.markerForeground": {
+          "type": "string",
+          "default": "#C586C0",
+          "description": "Foreground color for insert-start / insert-end markers."
+        },
+        "brickGenerator.colors.insert.contentBackground": {
+          "type": "string",
+          "default": "rgba(197, 134, 192, 0.14)",
+          "description": "Background color for content inside insert blocks."
+        },
+        "brickGenerator.colors.partial.markerForeground": {
+          "type": "string",
+          "default": "#569CD6",
+          "description": "Foreground color for partial v / partial ^ markers."
+        },
+        "brickGenerator.colors.partial.payloadBackground": {
+          "type": "string",
+          "default": "rgba(86, 156, 214, 0.14)",
+          "description": "Background color for the payload inside partial blocks."
+        },
+        "brickGenerator.colors.mustache.tagForeground": {
+          "type": "string",
+          "default": "#C678DD",
+          "description": "Foreground color for {{…}} mustache tags inside annotation comments."
+        },
+        "brickGenerator.colors.mustache.commentBackground": {
+          "type": "string",
+          "default": "rgba(198, 120, 221, 0.10)",
+          "description": "Background color for mustache annotation comments."
+        },
+        "brickGenerator.colors.mustache.dropFlagForeground": {
+          "type": "string",
+          "default": "#F48771",
+          "description": "Foreground color for the x drop-flag inside mustache annotation comments."
+        },
+        "brickGenerator.colors.spacing.markerForeground": {
+          "type": "string",
+          "default": "#A0A1A7",
+          "description": "Foreground color for spacing directives (w … w)."
+        },
+        "brickGenerator.colors.spacing.markerBackground": {
+          "type": "string",
+          "default": "rgba(160, 161, 167, 0.12)",
+          "description": "Background color for spacing directives (w … w)."
+        }
+      }
+    },
     "grammars": [
       {
         "scopeName": "brick-generator.injection",
@@ -31,7 +235,9 @@
           "source.shell",
           "source.yaml",
           "text.html",
-          "text.xml"
+          "text.xml",
+          "text.html.markdown",
+          "source.ignore"
         ]
       }
     ]

--- a/tools/vscode_extension/package.json
+++ b/tools/vscode_extension/package.json
@@ -59,8 +59,9 @@
           },
           {
             "scope": [
-              "keyword.annotation.brick-generator.partial",
-              "keyword.annotation.brick-generator.partial.marker"
+              "meta.annotation.brick-generator.partial",
+              "keyword.annotation.brick-generator.partial.marker",
+              "entity.name.section.brick-generator.partial"
             ],
             "settings": {
               "foreground": "#569CD6",
@@ -81,10 +82,8 @@
               "fontStyle": "bold"
             }
           }
-        ]
-      },
-      "[Default Light+]": {
-        "editor.tokenColorCustomizations": {
+        ],
+        "[Default Light+]": {
           "textMateRules": [
             {
               "scope": [
@@ -120,8 +119,9 @@
             },
             {
               "scope": [
-                "keyword.annotation.brick-generator.partial",
-                "keyword.annotation.brick-generator.partial.marker"
+                "meta.annotation.brick-generator.partial",
+                "keyword.annotation.brick-generator.partial.marker",
+                "entity.name.section.brick-generator.partial"
               ],
               "settings": {
                 "foreground": "#0451A5",

--- a/tools/vscode_extension/src/annotationColors.ts
+++ b/tools/vscode_extension/src/annotationColors.ts
@@ -1,0 +1,29 @@
+/** Discarded content — remove / drop. */
+export const removedMarkerForeground = '#F48771';
+export const removedContentBackground = 'rgba(244, 135, 113, 0.14)';
+
+/** Replace boundaries (replace-start / replace-end). */
+export const replaceBoundaryMarkerForeground = '#E5A84B';
+/** Replace pivot (with). */
+export const replaceWithMarkerForeground = '#4EC9B0';
+/** Scaffold replaced at generation time. */
+export const replaceOriginalBackground = 'rgba(229, 168, 75, 0.14)';
+/** Output kept after generation. */
+export const replaceReplacementBackground = 'rgba(78, 201, 176, 0.14)';
+
+/** Insert boundaries — content added at generation time. */
+export const insertedMarkerForeground = '#C586C0';
+export const insertedContentBackground = 'rgba(197, 134, 192, 0.14)';
+
+/** Partial boundaries — payload extracted to a partial file. */
+export const partialMarkerForeground = '#569CD6';
+export const partialPayloadBackground = 'rgba(86, 156, 214, 0.14)';
+
+/** Mustache variable tags in annotation comments. */
+export const mustacheTagForeground = '#C678DD';
+export const mustacheCommentBackground = 'rgba(198, 120, 221, 0.10)';
+export const mustacheDropFlagForeground = '#F48771';
+
+/** Spacing directives (w … w). */
+export const spacingMarkerForeground = '#A0A1A7';
+export const spacingMarkerBackground = 'rgba(160, 161, 167, 0.12)';

--- a/tools/vscode_extension/src/annotationConfig.ts
+++ b/tools/vscode_extension/src/annotationConfig.ts
@@ -1,0 +1,98 @@
+import * as vscode from 'vscode';
+
+import {
+  insertedContentBackground,
+  insertedMarkerForeground,
+  mustacheCommentBackground,
+  mustacheDropFlagForeground,
+  mustacheTagForeground,
+  partialMarkerForeground,
+  partialPayloadBackground,
+  removedContentBackground,
+  removedMarkerForeground,
+  replaceBoundaryMarkerForeground,
+  replaceOriginalBackground,
+  replaceReplacementBackground,
+  replaceWithMarkerForeground,
+  spacingMarkerBackground,
+  spacingMarkerForeground,
+} from './annotationColors';
+
+function get(key: string, fallback: string): string {
+  return (
+    vscode.workspace
+      .getConfiguration('brickGenerator.colors')
+      .get<string>(key) ?? fallback
+  );
+}
+
+export interface AnnotationConfig {
+  remove: {
+    markerForeground: string;
+    contentBackground: string;
+  };
+  replace: {
+    boundaryMarkerForeground: string;
+    withMarkerForeground: string;
+    originalBackground: string;
+    replacementBackground: string;
+  };
+  insert: {
+    markerForeground: string;
+    contentBackground: string;
+  };
+  partial: {
+    markerForeground: string;
+    payloadBackground: string;
+  };
+  mustache: {
+    tagForeground: string;
+    commentBackground: string;
+    dropFlagForeground: string;
+  };
+  spacing: {
+    markerForeground: string;
+    markerBackground: string;
+  };
+}
+
+export function readAnnotationConfig(): AnnotationConfig {
+  return {
+    remove: {
+      markerForeground: get('remove.markerForeground', removedMarkerForeground),
+      contentBackground: get('remove.contentBackground', removedContentBackground),
+    },
+    replace: {
+      boundaryMarkerForeground: get(
+        'replace.boundaryMarkerForeground',
+        replaceBoundaryMarkerForeground,
+      ),
+      withMarkerForeground: get(
+        'replace.withMarkerForeground',
+        replaceWithMarkerForeground,
+      ),
+      originalBackground: get('replace.originalBackground', replaceOriginalBackground),
+      replacementBackground: get(
+        'replace.replacementBackground',
+        replaceReplacementBackground,
+      ),
+    },
+    insert: {
+      markerForeground: get('insert.markerForeground', insertedMarkerForeground),
+      contentBackground: get('insert.contentBackground', insertedContentBackground),
+    },
+    partial: {
+      markerForeground: get('partial.markerForeground', partialMarkerForeground),
+      payloadBackground: get('partial.payloadBackground', partialPayloadBackground),
+    },
+    mustache: {
+      tagForeground: get('mustache.tagForeground', mustacheTagForeground),
+      commentBackground: get('mustache.commentBackground', mustacheCommentBackground),
+      dropFlagForeground: get('mustache.dropFlagForeground', mustacheDropFlagForeground),
+    },
+    spacing: {
+      markerForeground: get('spacing.markerForeground', spacingMarkerForeground),
+      markerBackground: get('spacing.markerBackground', spacingMarkerBackground),
+    },
+  };
+}

--- a/tools/vscode_extension/src/brickHighlighting.ts
+++ b/tools/vscode_extension/src/brickHighlighting.ts
@@ -1,0 +1,51 @@
+import * as vscode from 'vscode';
+
+import { readAnnotationConfig } from './annotationConfig';
+import { refreshInsertHighlights } from './insertHighlighting';
+import { refreshMustacheHighlights } from './mustacheHighlighting';
+import { refreshPartialHighlights } from './partialHighlighting';
+import { refreshRemoveHighlights } from './removeHighlighting';
+import { refreshReplaceHighlights } from './replaceHighlighting';
+import { refreshSpacingHighlights } from './spacingHighlighting';
+
+function refreshBrickHighlights(editor: vscode.TextEditor | undefined): void {
+  const config = readAnnotationConfig();
+  refreshRemoveHighlights(editor, config);
+  refreshReplaceHighlights(editor, config);
+  refreshInsertHighlights(editor, config);
+  refreshPartialHighlights(editor, config);
+  refreshMustacheHighlights(editor, config);
+  refreshSpacingHighlights(editor, config);
+}
+
+function refreshAllVisibleEditors(): void {
+  for (const editor of vscode.window.visibleTextEditors) {
+    refreshBrickHighlights(editor);
+  }
+}
+
+export function registerBrickHighlighting(context: vscode.ExtensionContext): void {
+  refreshAllVisibleEditors();
+
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(refreshBrickHighlights),
+    vscode.workspace.onDidChangeTextDocument((event) => {
+      refreshBrickHighlights(
+        vscode.window.visibleTextEditors.find(
+          (editor) => editor.document === event.document,
+        ),
+      );
+    }),
+    vscode.workspace.onDidOpenTextDocument((document) => {
+      refreshBrickHighlights(
+        vscode.window.visibleTextEditors.find(
+          (editor) => editor.document === document,
+        ),
+      );
+    }),
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (!event.affectsConfiguration('brickGenerator.colors')) return;
+      refreshAllVisibleEditors();
+    }),
+  );
+}

--- a/tools/vscode_extension/src/brickHighlighting.ts
+++ b/tools/vscode_extension/src/brickHighlighting.ts
@@ -24,24 +24,24 @@ function refreshAllVisibleEditors(): void {
   }
 }
 
+function refreshEditorsForDocument(document: vscode.TextDocument): void {
+  for (const editor of vscode.window.visibleTextEditors) {
+    if (editor.document === document) {
+      refreshBrickHighlights(editor);
+    }
+  }
+}
+
 export function registerBrickHighlighting(context: vscode.ExtensionContext): void {
   refreshAllVisibleEditors();
 
   context.subscriptions.push(
     vscode.window.onDidChangeActiveTextEditor(refreshBrickHighlights),
     vscode.workspace.onDidChangeTextDocument((event) => {
-      refreshBrickHighlights(
-        vscode.window.visibleTextEditors.find(
-          (editor) => editor.document === event.document,
-        ),
-      );
+      refreshEditorsForDocument(event.document);
     }),
     vscode.workspace.onDidOpenTextDocument((document) => {
-      refreshBrickHighlights(
-        vscode.window.visibleTextEditors.find(
-          (editor) => editor.document === document,
-        ),
-      );
+      refreshEditorsForDocument(document);
     }),
     vscode.workspace.onDidChangeConfiguration((event) => {
       if (!event.affectsConfiguration('brickGenerator.colors')) return;

--- a/tools/vscode_extension/src/extension.ts
+++ b/tools/vscode_extension/src/extension.ts
@@ -1,15 +1,30 @@
 import * as vscode from 'vscode';
 
+import { registerBrickHighlighting } from './brickHighlighting';
+import { registerInsertHighlighting } from './insertHighlighting';
+import { registerMustacheHighlighting } from './mustacheHighlighting';
+import { registerPartialHighlighting } from './partialHighlighting';
+import { registerRemoveHighlighting } from './removeHighlighting';
+import { registerReplaceHighlighting } from './replaceHighlighting';
+import { registerSpacingHighlighting } from './spacingHighlighting';
+
 /**
  * Activates the Brick Generator extension.
  *
- * Annotation syntax highlighting is contributed declaratively via TextMate
- * grammar injection. Folding, diagnostics, and preview register here later.
+ * Annotation syntax highlighting is contributed via TextMate grammar injection;
+ * annotation regions are tinted programmatically so colors apply reliably inside
+ * comment regions. Folding, diagnostics, and preview register here later.
  */
-export function activate(_context: vscode.ExtensionContext): void {
-  // No programmatic providers yet — grammar injection handles highlighting.
+export function activate(context: vscode.ExtensionContext): void {
+  registerRemoveHighlighting(context);
+  registerReplaceHighlighting(context);
+  registerInsertHighlighting(context);
+  registerPartialHighlighting(context);
+  registerMustacheHighlighting(context);
+  registerSpacingHighlighting(context);
+  registerBrickHighlighting(context);
 }
 
 export function deactivate(): void {
-  // Nothing to dispose yet.
+  // Subscriptions dispose via context.subscriptions.
 }

--- a/tools/vscode_extension/src/extension.ts
+++ b/tools/vscode_extension/src/extension.ts
@@ -3,11 +3,11 @@ import * as vscode from 'vscode';
 /**
  * Activates the Brick Generator extension.
  *
- * Annotation highlighting, folding, diagnostics, and preview are added in
- * follow-up changes; this entry point only wires the extension lifecycle.
+ * Annotation syntax highlighting is contributed declaratively via TextMate
+ * grammar injection. Folding, diagnostics, and preview register here later.
  */
 export function activate(_context: vscode.ExtensionContext): void {
-  // Scaffold — no features registered yet.
+  // No programmatic providers yet — grammar injection handles highlighting.
 }
 
 export function deactivate(): void {

--- a/tools/vscode_extension/src/insertHighlighting.ts
+++ b/tools/vscode_extension/src/insertHighlighting.ts
@@ -24,6 +24,28 @@ const INSERT_BOUNDARY_MARKER_PATTERN =
 
 let markerDecoration = vscode.window.createTextEditorDecorationType({});
 let contentDecoration = vscode.window.createTextEditorDecorationType({});
+let appliedConfigKey = '';
+
+function ensureDecorations(config: AnnotationConfig): void {
+  const key = JSON.stringify(config.insert);
+  if (key === appliedConfigKey) return;
+
+  const prevMarker = markerDecoration;
+  const prevContent = contentDecoration;
+
+  markerDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.insert.markerForeground,
+    fontWeight: 'bold',
+  });
+  contentDecoration = vscode.window.createTextEditorDecorationType({
+    backgroundColor: config.insert.contentBackground,
+    isWholeLine: false,
+  });
+
+  prevMarker.dispose();
+  prevContent.dispose();
+  appliedConfigKey = key;
+}
 
 function collectMarkers(text: string, pattern: RegExp, kind: MarkerKind): MarkerMatch[] {
   return collectRegexMatches(text, pattern).map((m) => ({ ...m, kind }));
@@ -58,20 +80,7 @@ export function refreshInsertHighlights(
   editor: vscode.TextEditor | undefined,
   config: AnnotationConfig,
 ): void {
-  const prevMarker = markerDecoration;
-  const prevContent = contentDecoration;
-
-  markerDecoration = vscode.window.createTextEditorDecorationType({
-    color: config.insert.markerForeground,
-    fontWeight: 'bold',
-  });
-  contentDecoration = vscode.window.createTextEditorDecorationType({
-    backgroundColor: config.insert.contentBackground,
-    isWholeLine: false,
-  });
-
-  prevMarker.dispose();
-  prevContent.dispose();
+  ensureDecorations(config);
 
   if (editor === undefined || !isSupportedBrickFile(editor.document)) return;
 

--- a/tools/vscode_extension/src/insertHighlighting.ts
+++ b/tools/vscode_extension/src/insertHighlighting.ts
@@ -1,0 +1,105 @@
+import * as vscode from 'vscode';
+
+import { type AnnotationConfig } from './annotationConfig';
+import { collectRegexMatches } from './markerScanning';
+import { interiorsToRanges } from './rangeUtils';
+import { isSupportedBrickFile } from './supportedFiles';
+
+type MarkerKind = 'start' | 'end';
+
+interface MarkerMatch {
+  kind: MarkerKind;
+  offset: number;
+  length: number;
+}
+
+const INSERT_MARKER_SETS = [
+  { start: /\/\*insert-start\*\//g, end: /\/\*insert-end\*\//g },
+  { start: /#insert-start#/g, end: /#insert-end#/g },
+  { start: /<!--insert-start-->/g, end: /<!--insert-end-->/g },
+];
+
+const INSERT_BOUNDARY_MARKER_PATTERN =
+  /\/\*insert-start\*\/|\/\*insert-end\*\/|#insert-start#|#insert-end#|<!--insert-start-->|<!--insert-end-->/g;
+
+let markerDecoration = vscode.window.createTextEditorDecorationType({});
+let contentDecoration = vscode.window.createTextEditorDecorationType({});
+
+function collectMarkers(text: string, pattern: RegExp, kind: MarkerKind): MarkerMatch[] {
+  return collectRegexMatches(text, pattern).map((m) => ({ ...m, kind }));
+}
+
+function findInsertBlockInteriors(text: string): Array<{ start: number; end: number }> {
+  const interiors: Array<{ start: number; end: number }> = [];
+
+  for (const markerSet of INSERT_MARKER_SETS) {
+    const markers = [
+      ...collectMarkers(text, markerSet.start, 'start'),
+      ...collectMarkers(text, markerSet.end, 'end'),
+    ].sort((a, b) => a.offset - b.offset);
+
+    const stack: MarkerMatch[] = [];
+    for (const marker of markers) {
+      if (marker.kind === 'start') { stack.push(marker); continue; }
+      if (stack.length === 0) continue;
+      const startMarker = stack.pop()!;
+      const interiorStart = startMarker.offset + startMarker.length;
+      const interiorEnd = marker.offset;
+      if (interiorEnd > interiorStart) {
+        interiors.push({ start: interiorStart, end: interiorEnd });
+      }
+    }
+  }
+
+  return interiors;
+}
+
+export function refreshInsertHighlights(
+  editor: vscode.TextEditor | undefined,
+  config: AnnotationConfig,
+): void {
+  const prevMarker = markerDecoration;
+  const prevContent = contentDecoration;
+
+  markerDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.insert.markerForeground,
+    fontWeight: 'bold',
+  });
+  contentDecoration = vscode.window.createTextEditorDecorationType({
+    backgroundColor: config.insert.contentBackground,
+    isWholeLine: false,
+  });
+
+  prevMarker.dispose();
+  prevContent.dispose();
+
+  if (editor === undefined || !isSupportedBrickFile(editor.document)) return;
+
+  const text = editor.document.getText();
+
+  editor.setDecorations(
+    markerDecoration,
+    [...text.matchAll(INSERT_BOUNDARY_MARKER_PATTERN)]
+      .filter((m) => m.index !== undefined)
+      .map((m) => {
+        const index = m.index!;
+        return new vscode.Range(
+          editor.document.positionAt(index),
+          editor.document.positionAt(index + m[0].length),
+        );
+      }),
+  );
+  editor.setDecorations(
+    contentDecoration,
+    interiorsToRanges(editor.document, findInsertBlockInteriors(text)),
+  );
+}
+
+export function registerInsertHighlighting(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    new vscode.Disposable(() => {
+      markerDecoration.dispose();
+      contentDecoration.dispose();
+    }),
+  );
+}

--- a/tools/vscode_extension/src/markerScanning.ts
+++ b/tools/vscode_extension/src/markerScanning.ts
@@ -1,0 +1,22 @@
+export interface TextMatch {
+  offset: number;
+  length: number;
+}
+
+export function collectRegexMatches(
+  text: string,
+  pattern: RegExp,
+): TextMatch[] {
+  const matches: TextMatch[] = [];
+  const expression = new RegExp(pattern.source, pattern.flags);
+
+  for (const match of text.matchAll(expression)) {
+    const offset = match.index;
+    if (offset === undefined) {
+      continue;
+    }
+    matches.push({ offset, length: match[0].length });
+  }
+
+  return matches;
+}

--- a/tools/vscode_extension/src/mustacheHighlighting.ts
+++ b/tools/vscode_extension/src/mustacheHighlighting.ts
@@ -8,9 +8,9 @@ import { isSupportedBrickFile } from './supportedFiles';
 const MUSTACHE_TAG = String.raw`\{\{[^}]*?\}\}`;
 
 const MUSTACHE_COMMENT_PATTERNS = [
-  new RegExp(String.raw`/\*(x)?(${MUSTACHE_TAG})(x)?\*/`, 'gd'),
-  new RegExp(String.raw`#(x)?(${MUSTACHE_TAG})(x)?#`, 'gd'),
-  new RegExp(String.raw`<!--(x)?(${MUSTACHE_TAG})(x)?-->`, 'gd'),
+  new RegExp(String.raw`/\*(x)?(${MUSTACHE_TAG})(x)?\*/`, 'g'),
+  new RegExp(String.raw`#(x)?(${MUSTACHE_TAG})(x)?#`, 'g'),
+  new RegExp(String.raw`<!--(x)?(${MUSTACHE_TAG})(x)?-->`, 'g'),
 ];
 
 let commentDecoration = vscode.window.createTextEditorDecorationType({});
@@ -62,7 +62,7 @@ function findMustacheHighlightRanges(document: vscode.TextDocument): {
 
       const leadingFlag = captureToRange(document, match, 1);
       const tag = captureToRange(document, match, 2);
-      const trailingFlag = captureToRange(document, match, 3);
+      const trailingFlag = captureToRange(document, match, 3, 'last');
 
       if (leadingFlag !== undefined) dropFlags.push(leadingFlag);
       if (tag !== undefined) tags.push(tag);

--- a/tools/vscode_extension/src/mustacheHighlighting.ts
+++ b/tools/vscode_extension/src/mustacheHighlighting.ts
@@ -1,0 +1,90 @@
+import * as vscode from 'vscode';
+
+import { type AnnotationConfig } from './annotationConfig';
+import { captureToRange, matchToRange } from './rangeUtils';
+import { isSupportedBrickFile } from './supportedFiles';
+
+/** Mustache tag body — allows `#` inside section tags (e.g. `{{#use_foo}}`). */
+const MUSTACHE_TAG = String.raw`\{\{[^}]*?\}\}`;
+
+const MUSTACHE_COMMENT_PATTERNS = [
+  new RegExp(String.raw`/\*(x)?(${MUSTACHE_TAG})(x)?\*/`, 'g'),
+  new RegExp(String.raw`#(x)?(${MUSTACHE_TAG})(x)?#`, 'g'),
+  new RegExp(String.raw`<!--(x)?(${MUSTACHE_TAG})(x)?-->`, 'g'),
+];
+
+let commentDecoration = vscode.window.createTextEditorDecorationType({});
+let tagDecoration = vscode.window.createTextEditorDecorationType({});
+let dropFlagDecoration = vscode.window.createTextEditorDecorationType({});
+
+function findMustacheHighlightRanges(document: vscode.TextDocument): {
+  comments: vscode.Range[];
+  tags: vscode.Range[];
+  dropFlags: vscode.Range[];
+} {
+  const text = document.getText();
+  const comments: vscode.Range[] = [];
+  const tags: vscode.Range[] = [];
+  const dropFlags: vscode.Range[] = [];
+
+  for (const pattern of MUSTACHE_COMMENT_PATTERNS) {
+    const expression = new RegExp(pattern.source, pattern.flags);
+    for (const match of text.matchAll(expression)) {
+      comments.push(matchToRange(document, match));
+
+      const leadingFlag = captureToRange(document, match, 1);
+      const tag = captureToRange(document, match, 2);
+      const trailingFlag = captureToRange(document, match, 3);
+
+      if (leadingFlag !== undefined) dropFlags.push(leadingFlag);
+      if (tag !== undefined) tags.push(tag);
+      if (trailingFlag !== undefined) dropFlags.push(trailingFlag);
+    }
+  }
+
+  return { comments, tags, dropFlags };
+}
+
+export function refreshMustacheHighlights(
+  editor: vscode.TextEditor | undefined,
+  config: AnnotationConfig,
+): void {
+  const prevComment = commentDecoration;
+  const prevTag = tagDecoration;
+  const prevDropFlag = dropFlagDecoration;
+
+  commentDecoration = vscode.window.createTextEditorDecorationType({
+    backgroundColor: config.mustache.commentBackground,
+    isWholeLine: false,
+  });
+  tagDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.mustache.tagForeground,
+    fontWeight: 'bold',
+  });
+  dropFlagDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.mustache.dropFlagForeground,
+    fontWeight: 'bold',
+  });
+
+  prevComment.dispose();
+  prevTag.dispose();
+  prevDropFlag.dispose();
+
+  if (editor === undefined || !isSupportedBrickFile(editor.document)) return;
+
+  const { comments, tags, dropFlags } = findMustacheHighlightRanges(editor.document);
+
+  editor.setDecorations(commentDecoration, comments);
+  editor.setDecorations(tagDecoration, tags);
+  editor.setDecorations(dropFlagDecoration, dropFlags);
+}
+
+export function registerMustacheHighlighting(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    new vscode.Disposable(() => {
+      commentDecoration.dispose();
+      tagDecoration.dispose();
+      dropFlagDecoration.dispose();
+    }),
+  );
+}

--- a/tools/vscode_extension/src/mustacheHighlighting.ts
+++ b/tools/vscode_extension/src/mustacheHighlighting.ts
@@ -16,6 +16,34 @@ const MUSTACHE_COMMENT_PATTERNS = [
 let commentDecoration = vscode.window.createTextEditorDecorationType({});
 let tagDecoration = vscode.window.createTextEditorDecorationType({});
 let dropFlagDecoration = vscode.window.createTextEditorDecorationType({});
+let appliedConfigKey = '';
+
+function ensureDecorations(config: AnnotationConfig): void {
+  const key = JSON.stringify(config.mustache);
+  if (key === appliedConfigKey) return;
+
+  const prevComment = commentDecoration;
+  const prevTag = tagDecoration;
+  const prevDropFlag = dropFlagDecoration;
+
+  commentDecoration = vscode.window.createTextEditorDecorationType({
+    backgroundColor: config.mustache.commentBackground,
+    isWholeLine: false,
+  });
+  tagDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.mustache.tagForeground,
+    fontWeight: 'bold',
+  });
+  dropFlagDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.mustache.dropFlagForeground,
+    fontWeight: 'bold',
+  });
+
+  prevComment.dispose();
+  prevTag.dispose();
+  prevDropFlag.dispose();
+  appliedConfigKey = key;
+}
 
 function findMustacheHighlightRanges(document: vscode.TextDocument): {
   comments: vscode.Range[];
@@ -49,26 +77,7 @@ export function refreshMustacheHighlights(
   editor: vscode.TextEditor | undefined,
   config: AnnotationConfig,
 ): void {
-  const prevComment = commentDecoration;
-  const prevTag = tagDecoration;
-  const prevDropFlag = dropFlagDecoration;
-
-  commentDecoration = vscode.window.createTextEditorDecorationType({
-    backgroundColor: config.mustache.commentBackground,
-    isWholeLine: false,
-  });
-  tagDecoration = vscode.window.createTextEditorDecorationType({
-    color: config.mustache.tagForeground,
-    fontWeight: 'bold',
-  });
-  dropFlagDecoration = vscode.window.createTextEditorDecorationType({
-    color: config.mustache.dropFlagForeground,
-    fontWeight: 'bold',
-  });
-
-  prevComment.dispose();
-  prevTag.dispose();
-  prevDropFlag.dispose();
+  ensureDecorations(config);
 
   if (editor === undefined || !isSupportedBrickFile(editor.document)) return;
 

--- a/tools/vscode_extension/src/mustacheHighlighting.ts
+++ b/tools/vscode_extension/src/mustacheHighlighting.ts
@@ -8,9 +8,9 @@ import { isSupportedBrickFile } from './supportedFiles';
 const MUSTACHE_TAG = String.raw`\{\{[^}]*?\}\}`;
 
 const MUSTACHE_COMMENT_PATTERNS = [
-  new RegExp(String.raw`/\*(x)?(${MUSTACHE_TAG})(x)?\*/`, 'g'),
-  new RegExp(String.raw`#(x)?(${MUSTACHE_TAG})(x)?#`, 'g'),
-  new RegExp(String.raw`<!--(x)?(${MUSTACHE_TAG})(x)?-->`, 'g'),
+  new RegExp(String.raw`/\*(x)?(${MUSTACHE_TAG})(x)?\*/`, 'gd'),
+  new RegExp(String.raw`#(x)?(${MUSTACHE_TAG})(x)?#`, 'gd'),
+  new RegExp(String.raw`<!--(x)?(${MUSTACHE_TAG})(x)?-->`, 'gd'),
 ];
 
 let commentDecoration = vscode.window.createTextEditorDecorationType({});

--- a/tools/vscode_extension/src/partialHighlighting.ts
+++ b/tools/vscode_extension/src/partialHighlighting.ts
@@ -24,6 +24,28 @@ const PARTIAL_BOUNDARY_MARKER_PATTERN =
 
 let markerDecoration = vscode.window.createTextEditorDecorationType({});
 let payloadDecoration = vscode.window.createTextEditorDecorationType({});
+let appliedConfigKey = '';
+
+function ensureDecorations(config: AnnotationConfig): void {
+  const key = JSON.stringify(config.partial);
+  if (key === appliedConfigKey) return;
+
+  const prevMarker = markerDecoration;
+  const prevPayload = payloadDecoration;
+
+  markerDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.partial.markerForeground,
+    fontWeight: 'bold',
+  });
+  payloadDecoration = vscode.window.createTextEditorDecorationType({
+    backgroundColor: config.partial.payloadBackground,
+    isWholeLine: false,
+  });
+
+  prevMarker.dispose();
+  prevPayload.dispose();
+  appliedConfigKey = key;
+}
 
 function collectPartialMarkers(
   text: string,
@@ -72,20 +94,7 @@ export function refreshPartialHighlights(
   editor: vscode.TextEditor | undefined,
   config: AnnotationConfig,
 ): void {
-  const prevMarker = markerDecoration;
-  const prevPayload = payloadDecoration;
-
-  markerDecoration = vscode.window.createTextEditorDecorationType({
-    color: config.partial.markerForeground,
-    fontWeight: 'bold',
-  });
-  payloadDecoration = vscode.window.createTextEditorDecorationType({
-    backgroundColor: config.partial.payloadBackground,
-    isWholeLine: false,
-  });
-
-  prevMarker.dispose();
-  prevPayload.dispose();
+  ensureDecorations(config);
 
   if (editor === undefined || !isSupportedBrickFile(editor.document)) return;
 

--- a/tools/vscode_extension/src/partialHighlighting.ts
+++ b/tools/vscode_extension/src/partialHighlighting.ts
@@ -1,0 +1,119 @@
+import * as vscode from 'vscode';
+
+import { type AnnotationConfig } from './annotationConfig';
+import { interiorsToRanges } from './rangeUtils';
+import { isSupportedBrickFile } from './supportedFiles';
+
+type PartialMarkerKind = 'start' | 'end';
+
+interface PartialMarker {
+  kind: PartialMarkerKind;
+  offset: number;
+  length: number;
+  name: string;
+}
+
+const PARTIAL_MARKER_SETS = [
+  { start: /\/\*partial v ([^*]+)\*\//g, end: /\/\*partial \^ ([^*]+)\*\//g },
+  { start: /#partial v ([^#]+)#/g, end: /#partial \^ ([^#]+)#/g },
+  { start: /<!--partial v ([^-]+)-->/g, end: /<!--partial \^ ([^-]+)-->/g },
+];
+
+const PARTIAL_BOUNDARY_MARKER_PATTERN =
+  /\/\*partial [v^] [^*]+\*\/|#partial [v^] [^#]+#|<!--partial [v^] [^-]+-->/g;
+
+let markerDecoration = vscode.window.createTextEditorDecorationType({});
+let payloadDecoration = vscode.window.createTextEditorDecorationType({});
+
+function collectPartialMarkers(
+  text: string,
+  pattern: RegExp,
+  kind: PartialMarkerKind,
+): PartialMarker[] {
+  const markers: PartialMarker[] = [];
+  const expression = new RegExp(pattern.source, pattern.flags);
+
+  for (const match of text.matchAll(expression)) {
+    const offset = match.index;
+    if (offset === undefined) continue;
+    markers.push({ kind, offset, length: match[0].length, name: (match[1] ?? '').trim() });
+  }
+
+  return markers;
+}
+
+function findPartialPayloadInteriors(text: string): Array<{ start: number; end: number }> {
+  const interiors: Array<{ start: number; end: number }> = [];
+
+  for (const markerSet of PARTIAL_MARKER_SETS) {
+    const markers = [
+      ...collectPartialMarkers(text, markerSet.start, 'start'),
+      ...collectPartialMarkers(text, markerSet.end, 'end'),
+    ].sort((a, b) => a.offset - b.offset);
+
+    const stack: PartialMarker[] = [];
+    for (const marker of markers) {
+      if (marker.kind === 'start') { stack.push(marker); continue; }
+      if (stack.length === 0) continue;
+      const startMarker = stack.pop()!;
+      if (startMarker.name !== marker.name) continue;
+      const interiorStart = startMarker.offset + startMarker.length;
+      const interiorEnd = marker.offset;
+      if (interiorEnd > interiorStart) {
+        interiors.push({ start: interiorStart, end: interiorEnd });
+      }
+    }
+  }
+
+  return interiors;
+}
+
+export function refreshPartialHighlights(
+  editor: vscode.TextEditor | undefined,
+  config: AnnotationConfig,
+): void {
+  const prevMarker = markerDecoration;
+  const prevPayload = payloadDecoration;
+
+  markerDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.partial.markerForeground,
+    fontWeight: 'bold',
+  });
+  payloadDecoration = vscode.window.createTextEditorDecorationType({
+    backgroundColor: config.partial.payloadBackground,
+    isWholeLine: false,
+  });
+
+  prevMarker.dispose();
+  prevPayload.dispose();
+
+  if (editor === undefined || !isSupportedBrickFile(editor.document)) return;
+
+  const text = editor.document.getText();
+
+  editor.setDecorations(
+    markerDecoration,
+    [...text.matchAll(PARTIAL_BOUNDARY_MARKER_PATTERN)]
+      .filter((m) => m.index !== undefined)
+      .map((m) => {
+        const index = m.index!;
+        return new vscode.Range(
+          editor.document.positionAt(index),
+          editor.document.positionAt(index + m[0].length),
+        );
+      }),
+  );
+  editor.setDecorations(
+    payloadDecoration,
+    interiorsToRanges(editor.document, findPartialPayloadInteriors(text)),
+  );
+}
+
+export function registerPartialHighlighting(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    new vscode.Disposable(() => {
+      markerDecoration.dispose();
+      payloadDecoration.dispose();
+    }),
+  );
+}

--- a/tools/vscode_extension/src/partialHighlighting.ts
+++ b/tools/vscode_extension/src/partialHighlighting.ts
@@ -58,7 +58,7 @@ function collectPartialMarkers(
   for (const match of text.matchAll(expression)) {
     const offset = match.index;
     if (offset === undefined) continue;
-    markers.push({ kind, offset, length: match[0].length, name: (match[1] ?? '').trim() });
+    markers.push({ kind, offset, length: match[0].length, name: match[1] ?? '' });
   }
 
   return markers;

--- a/tools/vscode_extension/src/partialHighlighting.ts
+++ b/tools/vscode_extension/src/partialHighlighting.ts
@@ -16,11 +16,11 @@ interface PartialMarker {
 const PARTIAL_MARKER_SETS = [
   { start: /\/\*partial v ([^*]+)\*\//g, end: /\/\*partial \^ ([^*]+)\*\//g },
   { start: /#partial v ([^#]+)#/g, end: /#partial \^ ([^#]+)#/g },
-  { start: /<!--partial v ([^-]+)-->/g, end: /<!--partial \^ ([^-]+)-->/g },
+  { start: /<!--partial v (.+?)-->/g, end: /<!--partial \^ (.+?)-->/g },
 ];
 
 const PARTIAL_BOUNDARY_MARKER_PATTERN =
-  /\/\*partial [v^] [^*]+\*\/|#partial [v^] [^#]+#|<!--partial [v^] [^-]+-->/g;
+  /\/\*partial [v^] [^*]+\*\/|#partial [v^] [^#]+#|<!--partial [v^] .+?-->/g;
 
 let markerDecoration = vscode.window.createTextEditorDecorationType({});
 let payloadDecoration = vscode.window.createTextEditorDecorationType({});

--- a/tools/vscode_extension/src/rangeUtils.ts
+++ b/tools/vscode_extension/src/rangeUtils.ts
@@ -1,0 +1,39 @@
+import * as vscode from 'vscode';
+
+export function interiorsToRanges(
+  document: vscode.TextDocument,
+  interiors: Array<{ start: number; end: number }>,
+): vscode.Range[] {
+  return interiors.map(
+    ({ start, end }) =>
+      new vscode.Range(document.positionAt(start), document.positionAt(end)),
+  );
+}
+
+export function matchToRange(
+  document: vscode.TextDocument,
+  match: RegExpMatchArray,
+): vscode.Range {
+  const index = match.index ?? 0;
+  return new vscode.Range(
+    document.positionAt(index),
+    document.positionAt(index + match[0].length),
+  );
+}
+
+export function captureToRange(
+  document: vscode.TextDocument,
+  match: RegExpMatchArray,
+  groupIndex: number,
+): vscode.Range | undefined {
+  const capture = match[groupIndex];
+  if (capture === undefined || capture.length === 0) {
+    return undefined;
+  }
+
+  const start = (match.index ?? 0) + match[0].indexOf(capture);
+  return new vscode.Range(
+    document.positionAt(start),
+    document.positionAt(start + capture.length),
+  );
+}

--- a/tools/vscode_extension/src/rangeUtils.ts
+++ b/tools/vscode_extension/src/rangeUtils.ts
@@ -25,17 +25,18 @@ export function captureToRange(
   document: vscode.TextDocument,
   match: RegExpMatchArray,
   groupIndex: number,
+  occurrence: 'first' | 'last' = 'first',
 ): vscode.Range | undefined {
   const capture = match[groupIndex];
   if (capture === undefined || capture.length === 0) {
     return undefined;
   }
 
-  const groupIndices = match.indices?.[groupIndex];
-  const start =
-    groupIndices !== undefined
-      ? groupIndices[0]
-      : (match.index ?? 0) + match[0].indexOf(capture);
+  const offsetInMatch =
+    occurrence === 'last'
+      ? match[0].lastIndexOf(capture)
+      : match[0].indexOf(capture);
+  const start = (match.index ?? 0) + offsetInMatch;
 
   return new vscode.Range(
     document.positionAt(start),

--- a/tools/vscode_extension/src/rangeUtils.ts
+++ b/tools/vscode_extension/src/rangeUtils.ts
@@ -31,7 +31,12 @@ export function captureToRange(
     return undefined;
   }
 
-  const start = (match.index ?? 0) + match[0].indexOf(capture);
+  const groupIndices = match.indices?.[groupIndex];
+  const start =
+    groupIndices !== undefined
+      ? groupIndices[0]
+      : (match.index ?? 0) + match[0].indexOf(capture);
+
   return new vscode.Range(
     document.positionAt(start),
     document.positionAt(start + capture.length),

--- a/tools/vscode_extension/src/removeHighlighting.ts
+++ b/tools/vscode_extension/src/removeHighlighting.ts
@@ -1,0 +1,141 @@
+import * as vscode from 'vscode';
+
+import { type AnnotationConfig } from './annotationConfig';
+import { collectRegexMatches } from './markerScanning';
+import { interiorsToRanges } from './rangeUtils';
+import { isSupportedBrickFile } from './supportedFiles';
+
+type MarkerKind = 'start' | 'end';
+
+interface MarkerMatch {
+  kind: MarkerKind;
+  offset: number;
+  length: number;
+}
+
+interface MarkerSet {
+  start: RegExp;
+  end: RegExp;
+}
+
+const REMOVE_MARKER_SETS: MarkerSet[] = [
+  { start: /\/\*(?:x-)?remove-start\*\//g, end: /\/\*remove-end(?:-x)?\*\//g },
+  { start: /#(?:x-)?remove-start#/g, end: /#remove-end(?:-x)?#/g },
+  { start: /<!--(?:x-)?remove-start-->/g, end: /<!--remove-end(?:-x)?-->/g },
+];
+
+const DROP_MARKER_SETS = [/\/\*drop\*\//g, /#drop#/g, /<!--drop-->/g];
+
+const REMOVE_BOUNDARY_MARKER_PATTERN =
+  /\/\*(?:x-)?remove-start\*\/|\/\*remove-end(?:-x)?\*\/|#(?:x-)?remove-start#|#remove-end(?:-x)?#|<!--(?:x-)?remove-start-->|<!--remove-end(?:-x)?-->/g;
+
+const DROP_MARKER_PATTERN = /\/\*drop\*\/|#drop#|<!--drop-->/g;
+
+let markerDecoration = vscode.window.createTextEditorDecorationType({});
+let contentDecoration = vscode.window.createTextEditorDecorationType({});
+
+function collectMarkers(text: string, pattern: RegExp, kind: MarkerKind): MarkerMatch[] {
+  return collectRegexMatches(text, pattern).map((m) => ({ ...m, kind }));
+}
+
+function findRemoveBlockInteriors(text: string): Array<{ start: number; end: number }> {
+  const interiors: Array<{ start: number; end: number }> = [];
+
+  for (const markerSet of REMOVE_MARKER_SETS) {
+    const markers = [
+      ...collectMarkers(text, markerSet.start, 'start'),
+      ...collectMarkers(text, markerSet.end, 'end'),
+    ].sort((a, b) => a.offset - b.offset);
+
+    const stack: MarkerMatch[] = [];
+    for (const marker of markers) {
+      if (marker.kind === 'start') { stack.push(marker); continue; }
+      if (stack.length === 0) continue;
+      const startMarker = stack.pop()!;
+      const interiorStart = startMarker.offset + startMarker.length;
+      const interiorEnd = marker.offset;
+      if (interiorEnd > interiorStart) {
+        interiors.push({ start: interiorStart, end: interiorEnd });
+      }
+    }
+  }
+
+  return interiors;
+}
+
+function findDropBlockInteriors(text: string): Array<{ start: number; end: number }> {
+  const interiors: Array<{ start: number; end: number }> = [];
+  const documentEnd = text.length;
+
+  for (const pattern of DROP_MARKER_SETS) {
+    for (const match of collectRegexMatches(text, pattern)) {
+      const interiorStart = match.offset + match.length;
+      if (documentEnd > interiorStart) {
+        interiors.push({ start: interiorStart, end: documentEnd });
+      }
+    }
+  }
+
+  return interiors;
+}
+
+function findRemovedBoundaryMarkerRanges(document: vscode.TextDocument): vscode.Range[] {
+  const text = document.getText();
+  const ranges: vscode.Range[] = [];
+
+  for (const pattern of [REMOVE_BOUNDARY_MARKER_PATTERN, DROP_MARKER_PATTERN]) {
+    for (const match of text.matchAll(pattern)) {
+      const index = match.index;
+      if (index === undefined) continue;
+      ranges.push(
+        new vscode.Range(
+          document.positionAt(index),
+          document.positionAt(index + match[0].length),
+        ),
+      );
+    }
+  }
+
+  return ranges;
+}
+
+export function refreshRemoveHighlights(
+  editor: vscode.TextEditor | undefined,
+  config: AnnotationConfig,
+): void {
+  const prevMarker = markerDecoration;
+  const prevContent = contentDecoration;
+
+  markerDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.remove.markerForeground,
+    fontWeight: 'bold',
+  });
+  contentDecoration = vscode.window.createTextEditorDecorationType({
+    backgroundColor: config.remove.contentBackground,
+    isWholeLine: false,
+  });
+
+  prevMarker.dispose();
+  prevContent.dispose();
+
+  if (editor === undefined || !isSupportedBrickFile(editor.document)) return;
+
+  const text = editor.document.getText();
+  editor.setDecorations(markerDecoration, findRemovedBoundaryMarkerRanges(editor.document));
+  editor.setDecorations(
+    contentDecoration,
+    interiorsToRanges(editor.document, [
+      ...findRemoveBlockInteriors(text),
+      ...findDropBlockInteriors(text),
+    ]),
+  );
+}
+
+export function registerRemoveHighlighting(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    new vscode.Disposable(() => {
+      markerDecoration.dispose();
+      contentDecoration.dispose();
+    }),
+  );
+}

--- a/tools/vscode_extension/src/removeHighlighting.ts
+++ b/tools/vscode_extension/src/removeHighlighting.ts
@@ -86,19 +86,25 @@ function findRemoveBlockInteriors(text: string): Array<{ start: number; end: num
 }
 
 function findDropBlockInteriors(text: string): Array<{ start: number; end: number }> {
-  const interiors: Array<{ start: number; end: number }> = [];
   const documentEnd = text.length;
+  let earliestInteriorStart: number | undefined;
 
   for (const pattern of DROP_MARKER_SETS) {
     for (const match of collectRegexMatches(text, pattern)) {
       const interiorStart = match.offset + match.length;
-      if (documentEnd > interiorStart) {
-        interiors.push({ start: interiorStart, end: documentEnd });
+      if (interiorStart >= documentEnd) continue;
+      if (
+        earliestInteriorStart === undefined ||
+        interiorStart < earliestInteriorStart
+      ) {
+        earliestInteriorStart = interiorStart;
       }
     }
   }
 
-  return interiors;
+  if (earliestInteriorStart === undefined) return [];
+
+  return [{ start: earliestInteriorStart, end: documentEnd }];
 }
 
 function findRemovedBoundaryMarkerRanges(document: vscode.TextDocument): vscode.Range[] {

--- a/tools/vscode_extension/src/removeHighlighting.ts
+++ b/tools/vscode_extension/src/removeHighlighting.ts
@@ -33,6 +33,28 @@ const DROP_MARKER_PATTERN = /\/\*drop\*\/|#drop#|<!--drop-->/g;
 
 let markerDecoration = vscode.window.createTextEditorDecorationType({});
 let contentDecoration = vscode.window.createTextEditorDecorationType({});
+let appliedConfigKey = '';
+
+function ensureDecorations(config: AnnotationConfig): void {
+  const key = JSON.stringify(config.remove);
+  if (key === appliedConfigKey) return;
+
+  const prevMarker = markerDecoration;
+  const prevContent = contentDecoration;
+
+  markerDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.remove.markerForeground,
+    fontWeight: 'bold',
+  });
+  contentDecoration = vscode.window.createTextEditorDecorationType({
+    backgroundColor: config.remove.contentBackground,
+    isWholeLine: false,
+  });
+
+  prevMarker.dispose();
+  prevContent.dispose();
+  appliedConfigKey = key;
+}
 
 function collectMarkers(text: string, pattern: RegExp, kind: MarkerKind): MarkerMatch[] {
   return collectRegexMatches(text, pattern).map((m) => ({ ...m, kind }));
@@ -103,20 +125,7 @@ export function refreshRemoveHighlights(
   editor: vscode.TextEditor | undefined,
   config: AnnotationConfig,
 ): void {
-  const prevMarker = markerDecoration;
-  const prevContent = contentDecoration;
-
-  markerDecoration = vscode.window.createTextEditorDecorationType({
-    color: config.remove.markerForeground,
-    fontWeight: 'bold',
-  });
-  contentDecoration = vscode.window.createTextEditorDecorationType({
-    backgroundColor: config.remove.contentBackground,
-    isWholeLine: false,
-  });
-
-  prevMarker.dispose();
-  prevContent.dispose();
+  ensureDecorations(config);
 
   if (editor === undefined || !isSupportedBrickFile(editor.document)) return;
 

--- a/tools/vscode_extension/src/replaceHighlighting.ts
+++ b/tools/vscode_extension/src/replaceHighlighting.ts
@@ -1,0 +1,200 @@
+import * as vscode from 'vscode';
+
+import { type AnnotationConfig } from './annotationConfig';
+import { collectRegexMatches, type TextMatch } from './markerScanning';
+import { interiorsToRanges } from './rangeUtils';
+import { isSupportedBrickFile } from './supportedFiles';
+
+type ReplaceMarkerKind = 'start' | 'with' | 'end';
+
+interface ReplaceMarker extends TextMatch {
+  kind: ReplaceMarkerKind;
+}
+
+interface ReplaceMarkerSet {
+  start: RegExp;
+  withMarker: RegExp;
+  end: RegExp;
+}
+
+const REPLACE_MARKER_SETS: ReplaceMarkerSet[] = [
+  {
+    start: /\/\*replace-start\*\//g,
+    withMarker: /\/\*with(?: +i\d+)?\*\//g,
+    end: /\/\*replace-end\*\//g,
+  },
+  {
+    start: /#replace-start#/g,
+    withMarker: /#with(?: +i\d+)?#/g,
+    end: /#replace-end#/g,
+  },
+  {
+    start: /<!--replace-start-->/g,
+    withMarker: /<!--with(?: +i\d+)?-->/g,
+    end: /<!--replace-end-->/g,
+  },
+];
+
+const REPLACE_START_END_MARKER_PATTERN =
+  /\/\*replace-start\*\/|\/\*replace-end\*\/|#replace-start#|#replace-end#|<!--replace-start-->|<!--replace-end-->/g;
+
+const WITH_MARKER_PATTERN =
+  /\/\*with(?: +i\d+)?\*\/|#with(?: +i\d+)?#|<!--with(?: +i\d+)?-->/g;
+
+let boundaryDecoration = vscode.window.createTextEditorDecorationType({});
+let withDecoration = vscode.window.createTextEditorDecorationType({});
+let originalDecoration = vscode.window.createTextEditorDecorationType({});
+let replacementDecoration = vscode.window.createTextEditorDecorationType({});
+
+function collectReplaceMarkers(
+  text: string,
+  pattern: RegExp,
+  kind: ReplaceMarkerKind,
+): ReplaceMarker[] {
+  return collectRegexMatches(text, pattern).map((m) => ({ ...m, kind }));
+}
+
+interface ReplaceBlockRegions {
+  originalInteriors: Array<{ start: number; end: number }>;
+  replacementInteriors: Array<{ start: number; end: number }>;
+}
+
+function findReplaceBlockRegions(text: string): ReplaceBlockRegions {
+  const originalInteriors: Array<{ start: number; end: number }> = [];
+  const replacementInteriors: Array<{ start: number; end: number }> = [];
+
+  for (const markerSet of REPLACE_MARKER_SETS) {
+    const markers = [
+      ...collectReplaceMarkers(text, markerSet.start, 'start'),
+      ...collectReplaceMarkers(text, markerSet.withMarker, 'with'),
+      ...collectReplaceMarkers(text, markerSet.end, 'end'),
+    ].sort((a, b) => a.offset - b.offset);
+
+    let expecting: ReplaceMarkerKind = 'start';
+    let blockStart: ReplaceMarker | undefined;
+    let withMarker: ReplaceMarker | undefined;
+
+    for (const marker of markers) {
+      switch (expecting) {
+        case 'start':
+          if (marker.kind === 'start') { blockStart = marker; expecting = 'with'; }
+          break;
+        case 'with':
+          if (marker.kind === 'with') {
+            if (blockStart !== undefined) {
+              const s = blockStart.offset + blockStart.length;
+              const e = marker.offset;
+              if (e > s) originalInteriors.push({ start: s, end: e });
+            }
+            withMarker = marker;
+            expecting = 'end';
+          } else if (marker.kind === 'start') {
+            blockStart = marker; withMarker = undefined;
+          } else {
+            expecting = 'start'; blockStart = undefined; withMarker = undefined;
+          }
+          break;
+        case 'end':
+          if (marker.kind === 'end') {
+            if (withMarker !== undefined) {
+              const s = withMarker.offset + withMarker.length;
+              const e = marker.offset;
+              if (e > s) replacementInteriors.push({ start: s, end: e });
+            }
+            expecting = 'start'; blockStart = undefined; withMarker = undefined;
+          } else if (marker.kind === 'start') {
+            blockStart = marker; withMarker = undefined; expecting = 'with';
+          } else {
+            withMarker = marker; expecting = 'end';
+          }
+          break;
+      }
+    }
+  }
+
+  return { originalInteriors, replacementInteriors };
+}
+
+function findRangesForPattern(
+  document: vscode.TextDocument,
+  pattern: RegExp,
+): vscode.Range[] {
+  const ranges: vscode.Range[] = [];
+  for (const match of document.getText().matchAll(pattern)) {
+    const index = match.index;
+    if (index === undefined) continue;
+    ranges.push(
+      new vscode.Range(
+        document.positionAt(index),
+        document.positionAt(index + match[0].length),
+      ),
+    );
+  }
+  return ranges;
+}
+
+export function refreshReplaceHighlights(
+  editor: vscode.TextEditor | undefined,
+  config: AnnotationConfig,
+): void {
+  const prevBoundary = boundaryDecoration;
+  const prevWith = withDecoration;
+  const prevOriginal = originalDecoration;
+  const prevReplacement = replacementDecoration;
+
+  boundaryDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.replace.boundaryMarkerForeground,
+    fontWeight: 'bold',
+  });
+  withDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.replace.withMarkerForeground,
+    fontWeight: 'bold',
+  });
+  originalDecoration = vscode.window.createTextEditorDecorationType({
+    backgroundColor: config.replace.originalBackground,
+    isWholeLine: false,
+  });
+  replacementDecoration = vscode.window.createTextEditorDecorationType({
+    backgroundColor: config.replace.replacementBackground,
+    isWholeLine: false,
+  });
+
+  prevBoundary.dispose();
+  prevWith.dispose();
+  prevOriginal.dispose();
+  prevReplacement.dispose();
+
+  if (editor === undefined || !isSupportedBrickFile(editor.document)) return;
+
+  const { originalInteriors, replacementInteriors } = findReplaceBlockRegions(
+    editor.document.getText(),
+  );
+
+  editor.setDecorations(
+    boundaryDecoration,
+    findRangesForPattern(editor.document, REPLACE_START_END_MARKER_PATTERN),
+  );
+  editor.setDecorations(
+    withDecoration,
+    findRangesForPattern(editor.document, WITH_MARKER_PATTERN),
+  );
+  editor.setDecorations(
+    originalDecoration,
+    interiorsToRanges(editor.document, originalInteriors),
+  );
+  editor.setDecorations(
+    replacementDecoration,
+    interiorsToRanges(editor.document, replacementInteriors),
+  );
+}
+
+export function registerReplaceHighlighting(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    new vscode.Disposable(() => {
+      boundaryDecoration.dispose();
+      withDecoration.dispose();
+      originalDecoration.dispose();
+      replacementDecoration.dispose();
+    }),
+  );
+}

--- a/tools/vscode_extension/src/replaceHighlighting.ts
+++ b/tools/vscode_extension/src/replaceHighlighting.ts
@@ -149,10 +149,11 @@ function findReplaceBlockRegions(text: string): ReplaceBlockRegions {
 
 function findRangesForPattern(
   document: vscode.TextDocument,
+  text: string,
   pattern: RegExp,
 ): vscode.Range[] {
   const ranges: vscode.Range[] = [];
-  for (const match of document.getText().matchAll(pattern)) {
+  for (const match of text.matchAll(pattern)) {
     const index = match.index;
     if (index === undefined) continue;
     ranges.push(
@@ -173,17 +174,16 @@ export function refreshReplaceHighlights(
 
   if (editor === undefined || !isSupportedBrickFile(editor.document)) return;
 
-  const { originalInteriors, replacementInteriors } = findReplaceBlockRegions(
-    editor.document.getText(),
-  );
+  const text = editor.document.getText();
+  const { originalInteriors, replacementInteriors } = findReplaceBlockRegions(text);
 
   editor.setDecorations(
     boundaryDecoration,
-    findRangesForPattern(editor.document, REPLACE_START_END_MARKER_PATTERN),
+    findRangesForPattern(editor.document, text, REPLACE_START_END_MARKER_PATTERN),
   );
   editor.setDecorations(
     withDecoration,
-    findRangesForPattern(editor.document, WITH_MARKER_PATTERN),
+    findRangesForPattern(editor.document, text, WITH_MARKER_PATTERN),
   );
   editor.setDecorations(
     originalDecoration,

--- a/tools/vscode_extension/src/replaceHighlighting.ts
+++ b/tools/vscode_extension/src/replaceHighlighting.ts
@@ -138,8 +138,6 @@ function findReplaceBlockRegions(text: string): ReplaceBlockRegions {
             expecting = 'start'; blockStart = undefined; withMarker = undefined;
           } else if (marker.kind === 'start') {
             blockStart = marker; withMarker = undefined; expecting = 'with';
-          } else {
-            withMarker = marker; expecting = 'end';
           }
           break;
       }

--- a/tools/vscode_extension/src/replaceHighlighting.ts
+++ b/tools/vscode_extension/src/replaceHighlighting.ts
@@ -45,6 +45,40 @@ let boundaryDecoration = vscode.window.createTextEditorDecorationType({});
 let withDecoration = vscode.window.createTextEditorDecorationType({});
 let originalDecoration = vscode.window.createTextEditorDecorationType({});
 let replacementDecoration = vscode.window.createTextEditorDecorationType({});
+let appliedConfigKey = '';
+
+function ensureDecorations(config: AnnotationConfig): void {
+  const key = JSON.stringify(config.replace);
+  if (key === appliedConfigKey) return;
+
+  const prevBoundary = boundaryDecoration;
+  const prevWith = withDecoration;
+  const prevOriginal = originalDecoration;
+  const prevReplacement = replacementDecoration;
+
+  boundaryDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.replace.boundaryMarkerForeground,
+    fontWeight: 'bold',
+  });
+  withDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.replace.withMarkerForeground,
+    fontWeight: 'bold',
+  });
+  originalDecoration = vscode.window.createTextEditorDecorationType({
+    backgroundColor: config.replace.originalBackground,
+    isWholeLine: false,
+  });
+  replacementDecoration = vscode.window.createTextEditorDecorationType({
+    backgroundColor: config.replace.replacementBackground,
+    isWholeLine: false,
+  });
+
+  prevBoundary.dispose();
+  prevWith.dispose();
+  prevOriginal.dispose();
+  prevReplacement.dispose();
+  appliedConfigKey = key;
+}
 
 function collectReplaceMarkers(
   text: string,
@@ -137,32 +171,7 @@ export function refreshReplaceHighlights(
   editor: vscode.TextEditor | undefined,
   config: AnnotationConfig,
 ): void {
-  const prevBoundary = boundaryDecoration;
-  const prevWith = withDecoration;
-  const prevOriginal = originalDecoration;
-  const prevReplacement = replacementDecoration;
-
-  boundaryDecoration = vscode.window.createTextEditorDecorationType({
-    color: config.replace.boundaryMarkerForeground,
-    fontWeight: 'bold',
-  });
-  withDecoration = vscode.window.createTextEditorDecorationType({
-    color: config.replace.withMarkerForeground,
-    fontWeight: 'bold',
-  });
-  originalDecoration = vscode.window.createTextEditorDecorationType({
-    backgroundColor: config.replace.originalBackground,
-    isWholeLine: false,
-  });
-  replacementDecoration = vscode.window.createTextEditorDecorationType({
-    backgroundColor: config.replace.replacementBackground,
-    isWholeLine: false,
-  });
-
-  prevBoundary.dispose();
-  prevWith.dispose();
-  prevOriginal.dispose();
-  prevReplacement.dispose();
+  ensureDecorations(config);
 
   if (editor === undefined || !isSupportedBrickFile(editor.document)) return;
 

--- a/tools/vscode_extension/src/spacingHighlighting.ts
+++ b/tools/vscode_extension/src/spacingHighlighting.ts
@@ -5,9 +5,9 @@ import { matchToRange } from './rangeUtils';
 import { isSupportedBrickFile } from './supportedFiles';
 
 const SPACING_MARKER_PATTERNS = [
-  /\/\*w (?:\d+[v>] )*w\*\//g,
-  /#w (?:\d+[v>] )*w#/g,
-  /<!--w (?:\d+[v>] )*w-->/g,
+  /\/\*w ?(?:\d+[v>] ?)* ?w\*\//g,
+  /#w ?(?:\d+[v>] ?)* ?w#/g,
+  /<!--w ?(?:\d+[v>] ?)* ?w-->/g,
 ];
 
 let spacingDecoration = vscode.window.createTextEditorDecorationType({});

--- a/tools/vscode_extension/src/spacingHighlighting.ts
+++ b/tools/vscode_extension/src/spacingHighlighting.ts
@@ -1,0 +1,52 @@
+import * as vscode from 'vscode';
+
+import { type AnnotationConfig } from './annotationConfig';
+import { matchToRange } from './rangeUtils';
+import { isSupportedBrickFile } from './supportedFiles';
+
+const SPACING_MARKER_PATTERNS = [
+  /\/\*w (?:\d+[v>] )*w\*\//g,
+  /#w (?:\d+[v>] )*w#/g,
+  /<!--w (?:\d+[v>] )*w-->/g,
+];
+
+let spacingDecoration = vscode.window.createTextEditorDecorationType({});
+
+function findSpacingMarkerRanges(document: vscode.TextDocument): vscode.Range[] {
+  const text = document.getText();
+  const ranges: vscode.Range[] = [];
+
+  for (const pattern of SPACING_MARKER_PATTERNS) {
+    const expression = new RegExp(pattern.source, pattern.flags);
+    for (const match of text.matchAll(expression)) {
+      ranges.push(matchToRange(document, match));
+    }
+  }
+
+  return ranges;
+}
+
+export function refreshSpacingHighlights(
+  editor: vscode.TextEditor | undefined,
+  config: AnnotationConfig,
+): void {
+  const prev = spacingDecoration;
+
+  spacingDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.spacing.markerForeground,
+    backgroundColor: config.spacing.markerBackground,
+    fontWeight: 'bold',
+  });
+
+  prev.dispose();
+
+  if (editor === undefined || !isSupportedBrickFile(editor.document)) return;
+
+  editor.setDecorations(spacingDecoration, findSpacingMarkerRanges(editor.document));
+}
+
+export function registerSpacingHighlighting(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    new vscode.Disposable(() => { spacingDecoration.dispose(); }),
+  );
+}

--- a/tools/vscode_extension/src/spacingHighlighting.ts
+++ b/tools/vscode_extension/src/spacingHighlighting.ts
@@ -11,6 +11,21 @@ const SPACING_MARKER_PATTERNS = [
 ];
 
 let spacingDecoration = vscode.window.createTextEditorDecorationType({});
+let appliedConfigKey = '';
+
+function ensureDecorations(config: AnnotationConfig): void {
+  const key = JSON.stringify(config.spacing);
+  if (key === appliedConfigKey) return;
+
+  const prev = spacingDecoration;
+  spacingDecoration = vscode.window.createTextEditorDecorationType({
+    color: config.spacing.markerForeground,
+    backgroundColor: config.spacing.markerBackground,
+    fontWeight: 'bold',
+  });
+  prev.dispose();
+  appliedConfigKey = key;
+}
 
 function findSpacingMarkerRanges(document: vscode.TextDocument): vscode.Range[] {
   const text = document.getText();
@@ -30,15 +45,7 @@ export function refreshSpacingHighlights(
   editor: vscode.TextEditor | undefined,
   config: AnnotationConfig,
 ): void {
-  const prev = spacingDecoration;
-
-  spacingDecoration = vscode.window.createTextEditorDecorationType({
-    color: config.spacing.markerForeground,
-    backgroundColor: config.spacing.markerBackground,
-    fontWeight: 'bold',
-  });
-
-  prev.dispose();
+  ensureDecorations(config);
 
   if (editor === undefined || !isSupportedBrickFile(editor.document)) return;
 

--- a/tools/vscode_extension/src/supportedFiles.ts
+++ b/tools/vscode_extension/src/supportedFiles.ts
@@ -1,0 +1,29 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+/** Extensions used by brick reference projects (see TIMELINE PR 3). */
+const SUPPORTED_EXTENSIONS = new Set([
+  '.dart',
+  '.sh',
+  '.yaml',
+  '.yml',
+  '.html',
+  '.htm',
+  '.xml',
+  '.md',
+  '.markdown',
+]);
+
+/** Ignore-style files that use `#` annotation comments without an extension. */
+const SUPPORTED_BASENAMES = new Set(['.gitignore', '.dockerignore']);
+
+export function isSupportedBrickFile(document: vscode.TextDocument): boolean {
+  const basename = path.basename(document.fileName).toLowerCase();
+  if (SUPPORTED_BASENAMES.has(basename)) {
+    return true;
+  }
+
+  return SUPPORTED_EXTENSIONS.has(
+    path.extname(document.fileName).toLowerCase(),
+  );
+}

--- a/tools/vscode_extension/syntaxes/brick-generator.tmLanguage.json
+++ b/tools/vscode_extension/syntaxes/brick-generator.tmLanguage.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/martinringert/language-json-schema/master/dist/textmate/syntax-tmLanguage.schema.json",
   "name": "Brick Generator Annotations",
   "scopeName": "brick-generator.injection",
-  "injectionSelector": "L:source",
+  "injectionSelector": "L:comment",
   "patterns": [
     { "include": "#dart-block-annotations" },
     { "include": "#hash-annotations" },
@@ -45,21 +45,7 @@
 
     "dart-remove": {
       "match": "/\\*(?:x-)?remove-start\\*/|/\\*remove-end(?:-x)?\\*/",
-      "name": "keyword.annotation.brick-generator.remove",
-      "captures": {
-        "0": {
-          "patterns": [
-            {
-              "match": "x-",
-              "name": "constant.language.brick-generator.drop-flag"
-            },
-            {
-              "match": "-x",
-              "name": "constant.language.brick-generator.drop-flag"
-            }
-          ]
-        }
-      }
+      "name": "keyword.annotation.brick-generator.remove"
     },
     "dart-replace": {
       "patterns": [
@@ -100,7 +86,7 @@
       }
     },
     "dart-mustache": {
-      "match": "/\\*(x)?(\\{\\{[^*]+\\}\\})(x)?\\*/",
+      "match": "/\\*(x)?(\\{\\{[^}]*?\\}\\})(x)?\\*/",
       "name": "meta.annotation.brick-generator.mustache",
       "captures": {
         "1": { "name": "constant.language.brick-generator.drop-flag" },
@@ -111,21 +97,7 @@
 
     "hash-remove": {
       "match": "#(?:x-)?remove-start#|#remove-end(?:-x)?#",
-      "name": "keyword.annotation.brick-generator.remove",
-      "captures": {
-        "0": {
-          "patterns": [
-            {
-              "match": "x-",
-              "name": "constant.language.brick-generator.drop-flag"
-            },
-            {
-              "match": "-x",
-              "name": "constant.language.brick-generator.drop-flag"
-            }
-          ]
-        }
-      }
+      "name": "keyword.annotation.brick-generator.remove"
     },
     "hash-replace": {
       "patterns": [
@@ -166,7 +138,7 @@
       }
     },
     "hash-mustache": {
-      "match": "#(x)?(\\{\\{[^#]+\\}\\})(x)?#",
+      "match": "#(x)?(\\{\\{[^}]*?\\}\\})(x)?#",
       "name": "meta.annotation.brick-generator.mustache",
       "captures": {
         "1": { "name": "constant.language.brick-generator.drop-flag" },
@@ -177,21 +149,7 @@
 
     "html-remove": {
       "match": "<!--(?:x-)?remove-start-->|<!--remove-end(?:-x)?-->",
-      "name": "keyword.annotation.brick-generator.remove",
-      "captures": {
-        "0": {
-          "patterns": [
-            {
-              "match": "x-",
-              "name": "constant.language.brick-generator.drop-flag"
-            },
-            {
-              "match": "-x",
-              "name": "constant.language.brick-generator.drop-flag"
-            }
-          ]
-        }
-      }
+      "name": "keyword.annotation.brick-generator.remove"
     },
     "html-replace": {
       "patterns": [
@@ -232,7 +190,7 @@
       }
     },
     "html-mustache": {
-      "match": "<!--(x)?(\\{\\{[^-]+\\}\\})(x)?-->",
+      "match": "<!--(x)?(\\{\\{[^}]*?\\}\\})(x)?-->",
       "name": "meta.annotation.brick-generator.mustache",
       "captures": {
         "1": { "name": "constant.language.brick-generator.drop-flag" },

--- a/tools/vscode_extension/syntaxes/brick-generator.tmLanguage.json
+++ b/tools/vscode_extension/syntaxes/brick-generator.tmLanguage.json
@@ -175,7 +175,7 @@
       "name": "keyword.annotation.brick-generator.drop"
     },
     "html-partial": {
-      "match": "<!--partial ([v^]) ([^-]+)-->",
+      "match": "<!--partial ([v^]) (.*?)-->",
       "name": "meta.annotation.brick-generator.partial",
       "captures": {
         "1": { "name": "keyword.annotation.brick-generator.partial.marker" },

--- a/tools/vscode_extension/syntaxes/brick-generator.tmLanguage.json
+++ b/tools/vscode_extension/syntaxes/brick-generator.tmLanguage.json
@@ -79,7 +79,7 @@
       }
     },
     "dart-spacing": {
-      "match": "/\\*w ((?:\\d+[v>] ?)*) w\\*/",
+      "match": "/\\*w ?((?:\\d+[v>] ?)*) ?w\\*/",
       "name": "meta.annotation.brick-generator.spacing",
       "captures": {
         "1": { "name": "constant.numeric.brick-generator.spacing" }
@@ -131,7 +131,7 @@
       }
     },
     "hash-spacing": {
-      "match": "#w ((?:\\d+[v>] ?)*) w#",
+      "match": "#w ?((?:\\d+[v>] ?)*) ?w#",
       "name": "meta.annotation.brick-generator.spacing",
       "captures": {
         "1": { "name": "constant.numeric.brick-generator.spacing" }
@@ -183,7 +183,7 @@
       }
     },
     "html-spacing": {
-      "match": "<!--w ((?:\\d+[v>] ?)*) w-->",
+      "match": "<!--w ?((?:\\d+[v>] ?)*) ?w-->",
       "name": "meta.annotation.brick-generator.spacing",
       "captures": {
         "1": { "name": "constant.numeric.brick-generator.spacing" }

--- a/tools/vscode_extension/syntaxes/brick-generator.tmLanguage.json
+++ b/tools/vscode_extension/syntaxes/brick-generator.tmLanguage.json
@@ -1,0 +1,244 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinringert/language-json-schema/master/dist/textmate/syntax-tmLanguage.schema.json",
+  "name": "Brick Generator Annotations",
+  "scopeName": "brick-generator.injection",
+  "injectionSelector": "L:source",
+  "patterns": [
+    { "include": "#dart-block-annotations" },
+    { "include": "#hash-annotations" },
+    { "include": "#html-annotations" }
+  ],
+  "repository": {
+    "dart-block-annotations": {
+      "patterns": [
+        { "include": "#dart-remove" },
+        { "include": "#dart-replace" },
+        { "include": "#dart-insert" },
+        { "include": "#dart-drop" },
+        { "include": "#dart-partial" },
+        { "include": "#dart-spacing" },
+        { "include": "#dart-mustache" }
+      ]
+    },
+    "hash-annotations": {
+      "patterns": [
+        { "include": "#hash-remove" },
+        { "include": "#hash-replace" },
+        { "include": "#hash-insert" },
+        { "include": "#hash-drop" },
+        { "include": "#hash-partial" },
+        { "include": "#hash-spacing" },
+        { "include": "#hash-mustache" }
+      ]
+    },
+    "html-annotations": {
+      "patterns": [
+        { "include": "#html-remove" },
+        { "include": "#html-replace" },
+        { "include": "#html-insert" },
+        { "include": "#html-drop" },
+        { "include": "#html-partial" },
+        { "include": "#html-spacing" },
+        { "include": "#html-mustache" }
+      ]
+    },
+
+    "dart-remove": {
+      "match": "/\\*(?:x-)?remove-start\\*/|/\\*remove-end(?:-x)?\\*/",
+      "name": "keyword.annotation.brick-generator.remove",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "match": "x-",
+              "name": "constant.language.brick-generator.drop-flag"
+            },
+            {
+              "match": "-x",
+              "name": "constant.language.brick-generator.drop-flag"
+            }
+          ]
+        }
+      }
+    },
+    "dart-replace": {
+      "patterns": [
+        {
+          "match": "/\\*replace-start\\*/|/\\*replace-end\\*/",
+          "name": "keyword.annotation.brick-generator.replace.boundary"
+        },
+        {
+          "match": "/\\*with(?: +i(\\d+))?\\*/",
+          "name": "keyword.annotation.brick-generator.replace.with",
+          "captures": {
+            "1": { "name": "constant.numeric.brick-generator.indent" }
+          }
+        }
+      ]
+    },
+    "dart-insert": {
+      "match": "/\\*insert-start\\*/|/\\*insert-end\\*/",
+      "name": "keyword.annotation.brick-generator.insert"
+    },
+    "dart-drop": {
+      "match": "/\\*drop\\*/",
+      "name": "keyword.annotation.brick-generator.drop"
+    },
+    "dart-partial": {
+      "match": "/\\*partial ([v^]) ([^*]+)\\*/",
+      "name": "meta.annotation.brick-generator.partial",
+      "captures": {
+        "1": { "name": "keyword.annotation.brick-generator.partial.marker" },
+        "2": { "name": "entity.name.section.brick-generator.partial" }
+      }
+    },
+    "dart-spacing": {
+      "match": "/\\*w ((?:\\d+[v>] ?)*) w\\*/",
+      "name": "meta.annotation.brick-generator.spacing",
+      "captures": {
+        "1": { "name": "constant.numeric.brick-generator.spacing" }
+      }
+    },
+    "dart-mustache": {
+      "match": "/\\*(x)?(\\{\\{[^*]+\\}\\})(x)?\\*/",
+      "name": "meta.annotation.brick-generator.mustache",
+      "captures": {
+        "1": { "name": "constant.language.brick-generator.drop-flag" },
+        "2": { "name": "entity.name.tag.mustache.brick-generator" },
+        "3": { "name": "constant.language.brick-generator.drop-flag" }
+      }
+    },
+
+    "hash-remove": {
+      "match": "#(?:x-)?remove-start#|#remove-end(?:-x)?#",
+      "name": "keyword.annotation.brick-generator.remove",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "match": "x-",
+              "name": "constant.language.brick-generator.drop-flag"
+            },
+            {
+              "match": "-x",
+              "name": "constant.language.brick-generator.drop-flag"
+            }
+          ]
+        }
+      }
+    },
+    "hash-replace": {
+      "patterns": [
+        {
+          "match": "#replace-start#|#replace-end#",
+          "name": "keyword.annotation.brick-generator.replace.boundary"
+        },
+        {
+          "match": "#with(?: +i(\\d+))?#",
+          "name": "keyword.annotation.brick-generator.replace.with",
+          "captures": {
+            "1": { "name": "constant.numeric.brick-generator.indent" }
+          }
+        }
+      ]
+    },
+    "hash-insert": {
+      "match": "#insert-start#|#insert-end#",
+      "name": "keyword.annotation.brick-generator.insert"
+    },
+    "hash-drop": {
+      "match": "#drop#",
+      "name": "keyword.annotation.brick-generator.drop"
+    },
+    "hash-partial": {
+      "match": "#partial ([v^]) ([^#]+)#",
+      "name": "meta.annotation.brick-generator.partial",
+      "captures": {
+        "1": { "name": "keyword.annotation.brick-generator.partial.marker" },
+        "2": { "name": "entity.name.section.brick-generator.partial" }
+      }
+    },
+    "hash-spacing": {
+      "match": "#w ((?:\\d+[v>] ?)*) w#",
+      "name": "meta.annotation.brick-generator.spacing",
+      "captures": {
+        "1": { "name": "constant.numeric.brick-generator.spacing" }
+      }
+    },
+    "hash-mustache": {
+      "match": "#(x)?(\\{\\{[^#]+\\}\\})(x)?#",
+      "name": "meta.annotation.brick-generator.mustache",
+      "captures": {
+        "1": { "name": "constant.language.brick-generator.drop-flag" },
+        "2": { "name": "entity.name.tag.mustache.brick-generator" },
+        "3": { "name": "constant.language.brick-generator.drop-flag" }
+      }
+    },
+
+    "html-remove": {
+      "match": "<!--(?:x-)?remove-start-->|<!--remove-end(?:-x)?-->",
+      "name": "keyword.annotation.brick-generator.remove",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "match": "x-",
+              "name": "constant.language.brick-generator.drop-flag"
+            },
+            {
+              "match": "-x",
+              "name": "constant.language.brick-generator.drop-flag"
+            }
+          ]
+        }
+      }
+    },
+    "html-replace": {
+      "patterns": [
+        {
+          "match": "<!--replace-start-->|<!--replace-end-->",
+          "name": "keyword.annotation.brick-generator.replace.boundary"
+        },
+        {
+          "match": "<!--with(?: +i(\\d+))?-->",
+          "name": "keyword.annotation.brick-generator.replace.with",
+          "captures": {
+            "1": { "name": "constant.numeric.brick-generator.indent" }
+          }
+        }
+      ]
+    },
+    "html-insert": {
+      "match": "<!--insert-start-->|<!--insert-end-->",
+      "name": "keyword.annotation.brick-generator.insert"
+    },
+    "html-drop": {
+      "match": "<!--drop-->",
+      "name": "keyword.annotation.brick-generator.drop"
+    },
+    "html-partial": {
+      "match": "<!--partial ([v^]) ([^-]+)-->",
+      "name": "meta.annotation.brick-generator.partial",
+      "captures": {
+        "1": { "name": "keyword.annotation.brick-generator.partial.marker" },
+        "2": { "name": "entity.name.section.brick-generator.partial" }
+      }
+    },
+    "html-spacing": {
+      "match": "<!--w ((?:\\d+[v>] ?)*) w-->",
+      "name": "meta.annotation.brick-generator.spacing",
+      "captures": {
+        "1": { "name": "constant.numeric.brick-generator.spacing" }
+      }
+    },
+    "html-mustache": {
+      "match": "<!--(x)?(\\{\\{[^-]+\\}\\})(x)?-->",
+      "name": "meta.annotation.brick-generator.mustache",
+      "captures": {
+        "1": { "name": "constant.language.brick-generator.drop-flag" },
+        "2": { "name": "entity.name.tag.mustache.brick-generator" },
+        "3": { "name": "constant.language.brick-generator.drop-flag" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview
- add comprehensive annotation highlighting across remove, replace, insert, partial, mustache, spacing, and drop markers
- support range-based shading for annotation block contents and improve behavior across supported file types
- introduce user-configurable color settings for foreground/background styles while preserving current defaults
- stabilize highlight lifecycle so decorations persist correctly when switching editors or tabs