### PR TITLE
feat(vscode-ext): add block folding for remove-start/end blocks

### DIFF
--- a/tools/vscode_extension/README.md
+++ b/tools/vscode_extension/README.md
@@ -8,10 +8,11 @@ The extension now provides annotation-aware highlighting for all currently suppo
 
 - Marker highlighting for: `remove-start/end`, `drop`, `replace-start/with/end`, `insert-start/end`, `partial v/^`, Mustache tags (`{{...}}`) inside comment annotations, and spacing directives (`w ... w`)
 - Block/range shading for: remove blocks, drop tails, replace original/replacement segments, insert blocks, and partial payload blocks
+- Code folding for: `remove-start/end`, `replace-start/end`, and matching `partial v/^` blocks (all three comment flavors)
 - Coverage across reference file types used in this monorepo, including `.dart`, `.sh`, `.yaml`, `.yml`, `.html`, `.xml`, `.md`, and ignore-style files such as `.gitignore`
 - Theme-friendly TextMate scopes with extension-provided defaults for both dark and light themes
 
-Folding, diagnostics, and inline preview land in follow-up changes.
+Diagnostics and inline preview land in follow-up changes.
 
 ## Customizing annotation colors
 

--- a/tools/vscode_extension/src/annotationBlockPairing.ts
+++ b/tools/vscode_extension/src/annotationBlockPairing.ts
@@ -11,6 +11,7 @@ export interface MarkerMatch {
 export interface TextSpan {
   start: number;
   end: number;
+  endMarkerStart?: number;
 }
 
 export interface StartEndMarkerSet {
@@ -89,6 +90,7 @@ function pairStartEndMarkers(markers: MarkerMatch[]): TextSpan[] {
     spans.push({
       start: startMarker.offset,
       end: marker.offset + marker.length,
+      endMarkerStart: marker.offset,
     });
   }
 
@@ -181,6 +183,7 @@ export function findNamedPairedBlockSpans(
       spans.push({
         start: startMarker.offset,
         end: marker.offset + marker.length,
+        endMarkerStart: marker.offset,
       });
     }
   }

--- a/tools/vscode_extension/src/annotationBlockPairing.ts
+++ b/tools/vscode_extension/src/annotationBlockPairing.ts
@@ -60,19 +60,6 @@ function collectNamedMarkers(
   return markers;
 }
 
-function findMatchingNamedStartIndex(
-  stack: NamedMarkerMatch[],
-  name: string,
-): number {
-  for (let index = stack.length - 1; index >= 0; index--) {
-    if (stack[index].name === name) {
-      return index;
-    }
-  }
-
-  return -1;
-}
-
 function pairStartEndMarkers(markers: MarkerMatch[]): TextSpan[] {
   const spans: TextSpan[] = [];
   const stack: MarkerMatch[] = [];
@@ -174,12 +161,12 @@ export function findNamedPairedBlockSpans(
         continue;
       }
 
-      const startIndex = findMatchingNamedStartIndex(stack, marker.name);
-      if (startIndex === -1) {
+      const startMarker = stack.at(-1);
+      if (startMarker === undefined || startMarker.name !== marker.name) {
         continue;
       }
 
-      const startMarker = stack.splice(startIndex, 1)[0];
+      stack.pop();
       spans.push({
         start: startMarker.offset,
         end: marker.offset + marker.length,

--- a/tools/vscode_extension/src/annotationBlockPairing.ts
+++ b/tools/vscode_extension/src/annotationBlockPairing.ts
@@ -1,0 +1,175 @@
+import { collectRegexMatches } from './markerScanning';
+
+export type MarkerKind = 'start' | 'end';
+
+export interface MarkerMatch {
+  kind: MarkerKind;
+  offset: number;
+  length: number;
+}
+
+export interface TextSpan {
+  start: number;
+  end: number;
+}
+
+export interface StartEndMarkerSet {
+  start: RegExp;
+  end: RegExp;
+}
+
+export interface NamedMarkerMatch extends MarkerMatch {
+  name: string;
+}
+
+export interface NamedStartEndMarkerSet {
+  start: RegExp;
+  end: RegExp;
+}
+
+function collectMarkers(
+  text: string,
+  pattern: RegExp,
+  kind: MarkerKind,
+): MarkerMatch[] {
+  return collectRegexMatches(text, pattern).map((match) => ({ ...match, kind }));
+}
+
+function collectNamedMarkers(
+  text: string,
+  pattern: RegExp,
+  kind: MarkerKind,
+): NamedMarkerMatch[] {
+  const markers: NamedMarkerMatch[] = [];
+  const expression = new RegExp(pattern.source, pattern.flags);
+
+  for (const match of text.matchAll(expression)) {
+    const offset = match.index;
+    if (offset === undefined) {
+      continue;
+    }
+    markers.push({
+      kind,
+      offset,
+      length: match[0].length,
+      name: match[1] ?? '',
+    });
+  }
+
+  return markers;
+}
+
+function pairStartEndMarkers(markers: MarkerMatch[]): TextSpan[] {
+  const spans: TextSpan[] = [];
+  const stack: MarkerMatch[] = [];
+
+  for (const marker of markers) {
+    if (marker.kind === 'start') {
+      stack.push(marker);
+      continue;
+    }
+    if (stack.length === 0) {
+      continue;
+    }
+
+    const startMarker = stack.pop()!;
+    spans.push({
+      start: startMarker.offset,
+      end: marker.offset + marker.length,
+    });
+  }
+
+  return spans;
+}
+
+/** Full spans from each start marker through its matching end marker (inclusive). */
+export function findPairedBlockSpans(
+  text: string,
+  markerSets: StartEndMarkerSet[],
+): TextSpan[] {
+  const spans: TextSpan[] = [];
+
+  for (const markerSet of markerSets) {
+    const markers = [
+      ...collectMarkers(text, markerSet.start, 'start'),
+      ...collectMarkers(text, markerSet.end, 'end'),
+    ].sort((a, b) => a.offset - b.offset);
+
+    spans.push(...pairStartEndMarkers(markers));
+  }
+
+  return spans;
+}
+
+/** Interior spans between paired start/end markers (exclusive of the markers). */
+export function findPairedBlockInteriors(
+  text: string,
+  markerSets: StartEndMarkerSet[],
+): TextSpan[] {
+  const interiors: TextSpan[] = [];
+
+  for (const markerSet of markerSets) {
+    const markers = [
+      ...collectMarkers(text, markerSet.start, 'start'),
+      ...collectMarkers(text, markerSet.end, 'end'),
+    ].sort((a, b) => a.offset - b.offset);
+
+    const stack: MarkerMatch[] = [];
+    for (const marker of markers) {
+      if (marker.kind === 'start') {
+        stack.push(marker);
+        continue;
+      }
+      if (stack.length === 0) {
+        continue;
+      }
+
+      const startMarker = stack.pop()!;
+      const interiorStart = startMarker.offset + startMarker.length;
+      const interiorEnd = marker.offset;
+      if (interiorEnd > interiorStart) {
+        interiors.push({ start: interiorStart, end: interiorEnd });
+      }
+    }
+  }
+
+  return interiors;
+}
+
+/** Full spans for named partial blocks (`partial v` / `partial ^` with matching names). */
+export function findNamedPairedBlockSpans(
+  text: string,
+  markerSets: NamedStartEndMarkerSet[],
+): TextSpan[] {
+  const spans: TextSpan[] = [];
+
+  for (const markerSet of markerSets) {
+    const markers = [
+      ...collectNamedMarkers(text, markerSet.start, 'start'),
+      ...collectNamedMarkers(text, markerSet.end, 'end'),
+    ].sort((a, b) => a.offset - b.offset);
+
+    const stack: NamedMarkerMatch[] = [];
+    for (const marker of markers) {
+      if (marker.kind === 'start') {
+        stack.push(marker);
+        continue;
+      }
+      if (stack.length === 0) {
+        continue;
+      }
+
+      const startMarker = stack.pop()!;
+      if (startMarker.name !== marker.name) {
+        continue;
+      }
+
+      spans.push({
+        start: startMarker.offset,
+        end: marker.offset + marker.length,
+      });
+    }
+  }
+
+  return spans;
+}

--- a/tools/vscode_extension/src/annotationBlockPairing.ts
+++ b/tools/vscode_extension/src/annotationBlockPairing.ts
@@ -59,6 +59,19 @@ function collectNamedMarkers(
   return markers;
 }
 
+function findMatchingNamedStartIndex(
+  stack: NamedMarkerMatch[],
+  name: string,
+): number {
+  for (let index = stack.length - 1; index >= 0; index--) {
+    if (stack[index].name === name) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
 function pairStartEndMarkers(markers: MarkerMatch[]): TextSpan[] {
   const spans: TextSpan[] = [];
   const stack: MarkerMatch[] = [];
@@ -159,11 +172,12 @@ export function findNamedPairedBlockSpans(
         continue;
       }
 
-      const startMarker = stack.pop()!;
-      if (startMarker.name !== marker.name) {
+      const startIndex = findMatchingNamedStartIndex(stack, marker.name);
+      if (startIndex === -1) {
         continue;
       }
 
+      const startMarker = stack.splice(startIndex, 1)[0];
       spans.push({
         start: startMarker.offset,
         end: marker.offset + marker.length,

--- a/tools/vscode_extension/src/annotationMarkerSets.ts
+++ b/tools/vscode_extension/src/annotationMarkerSets.ts
@@ -1,0 +1,29 @@
+import {
+  type NamedStartEndMarkerSet,
+  type StartEndMarkerSet,
+} from './annotationBlockPairing';
+
+export const REMOVE_MARKER_SETS: StartEndMarkerSet[] = [
+  { start: /\/\*(?:x-)?remove-start\*\//g, end: /\/\*remove-end(?:-x)?\*\//g },
+  { start: /#(?:x-)?remove-start#/g, end: /#remove-end(?:-x)?#/g },
+  { start: /<!--(?:x-)?remove-start-->/g, end: /<!--remove-end(?:-x)?-->/g },
+];
+
+export const REPLACE_MARKER_SETS: StartEndMarkerSet[] = [
+  { start: /\/\*replace-start\*\//g, end: /\/\*replace-end\*\//g },
+  { start: /#replace-start#/g, end: /#replace-end#/g },
+  { start: /<!--replace-start-->/g, end: /<!--replace-end-->/g },
+];
+
+export const PARTIAL_MARKER_SETS: NamedStartEndMarkerSet[] = [
+  { start: /\/\*partial v ([^*]+)\*\//g, end: /\/\*partial \^ ([^*]+)\*\//g },
+  { start: /#partial v ([^#]+)#/g, end: /#partial \^ ([^#]+)#/g },
+  { start: /<!--partial v (.+?)-->/g, end: /<!--partial \^ (.+?)-->/g },
+];
+
+export const REMOVE_BOUNDARY_MARKER_PATTERN =
+  /\/\*(?:x-)?remove-start\*\/|\/\*remove-end(?:-x)?\*\/|#(?:x-)?remove-start#|#remove-end(?:-x)?#|<!--(?:x-)?remove-start-->|<!--remove-end(?:-x)?-->/g;
+
+export const DROP_MARKER_SETS = [/\/\*drop\*\//g, /#drop#/g, /<!--drop-->/g];
+
+export const DROP_MARKER_PATTERN = /\/\*drop\*\/|#drop#|<!--drop-->/g;

--- a/tools/vscode_extension/src/blockFolding.ts
+++ b/tools/vscode_extension/src/blockFolding.ts
@@ -10,22 +10,16 @@ import {
   REMOVE_MARKER_SETS,
   REPLACE_MARKER_SETS,
 } from './annotationMarkerSets';
+import { spanToFoldingRange } from './rangeUtils';
 import { isSupportedBrickFile } from './supportedFiles';
 
 function spansToFoldingRanges(
   document: vscode.TextDocument,
   spans: TextSpan[],
 ): vscode.FoldingRange[] {
-  return spans.map(({ start, end }) => {
-    const startLine = document.positionAt(start).line;
-    const endLine = document.positionAt(Math.max(start, end - 1)).line;
-
-    return new vscode.FoldingRange(
-      startLine,
-      endLine,
-      vscode.FoldingRangeKind.Region,
-    );
-  });
+  return spans
+    .map((span) => spanToFoldingRange(document, span))
+    .filter((range): range is vscode.FoldingRange => range !== undefined);
 }
 
 function collectAnnotationFoldingRanges(

--- a/tools/vscode_extension/src/blockFolding.ts
+++ b/tools/vscode_extension/src/blockFolding.ts
@@ -1,0 +1,58 @@
+import * as vscode from 'vscode';
+
+import {
+  findNamedPairedBlockSpans,
+  findPairedBlockSpans,
+  type TextSpan,
+} from './annotationBlockPairing';
+import {
+  PARTIAL_MARKER_SETS,
+  REMOVE_MARKER_SETS,
+  REPLACE_MARKER_SETS,
+} from './annotationMarkerSets';
+import { isSupportedBrickFile } from './supportedFiles';
+
+function spansToFoldingRanges(
+  document: vscode.TextDocument,
+  spans: TextSpan[],
+): vscode.FoldingRange[] {
+  return spans.map(({ start, end }) => {
+    const startLine = document.positionAt(start).line;
+    const endLine = document.positionAt(Math.max(start, end - 1)).line;
+
+    return new vscode.FoldingRange(
+      startLine,
+      endLine,
+      vscode.FoldingRangeKind.Region,
+    );
+  });
+}
+
+function collectAnnotationFoldingRanges(
+  document: vscode.TextDocument,
+): vscode.FoldingRange[] {
+  const text = document.getText();
+  const spans = [
+    ...findPairedBlockSpans(text, REMOVE_MARKER_SETS),
+    ...findPairedBlockSpans(text, REPLACE_MARKER_SETS),
+    ...findNamedPairedBlockSpans(text, PARTIAL_MARKER_SETS),
+  ];
+
+  return spansToFoldingRanges(document, spans);
+}
+
+export function registerBlockFolding(context: vscode.ExtensionContext): void {
+  const provider: vscode.FoldingRangeProvider = {
+    provideFoldingRanges(document) {
+      if (!isSupportedBrickFile(document)) {
+        return [];
+      }
+
+      return collectAnnotationFoldingRanges(document);
+    },
+  };
+
+  context.subscriptions.push(
+    vscode.languages.registerFoldingRangeProvider({ scheme: 'file' }, provider),
+  );
+}

--- a/tools/vscode_extension/src/extension.ts
+++ b/tools/vscode_extension/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { registerBlockFolding } from './blockFolding';
 import { registerBrickHighlighting } from './brickHighlighting';
 import { registerInsertHighlighting } from './insertHighlighting';
 import { registerMustacheHighlighting } from './mustacheHighlighting';
@@ -13,9 +14,10 @@ import { registerSpacingHighlighting } from './spacingHighlighting';
  *
  * Annotation syntax highlighting is contributed via TextMate grammar injection;
  * annotation regions are tinted programmatically so colors apply reliably inside
- * comment regions. Folding, diagnostics, and preview register here later.
+ * comment regions. Diagnostics and preview register here later.
  */
 export function activate(context: vscode.ExtensionContext): void {
+  registerBlockFolding(context);
   registerRemoveHighlighting(context);
   registerReplaceHighlighting(context);
   registerInsertHighlighting(context);

--- a/tools/vscode_extension/src/rangeUtils.ts
+++ b/tools/vscode_extension/src/rangeUtils.ts
@@ -43,3 +43,55 @@ export function captureToRange(
     document.positionAt(start + capture.length),
   );
 }
+
+function hasNonWhitespaceBefore(
+  document: vscode.TextDocument,
+  offset: number,
+): boolean {
+  const line = document.lineAt(document.positionAt(offset).line);
+  const before = document.getText(
+    new vscode.Range(line.range.start, document.positionAt(offset)),
+  );
+  return before.trim().length > 0;
+}
+
+function hasNonWhitespaceAfter(
+  document: vscode.TextDocument,
+  offset: number,
+): boolean {
+  const line = document.lineAt(document.positionAt(offset).line);
+  const after = document.getText(
+    new vscode.Range(document.positionAt(offset), line.range.end),
+  );
+  return after.trim().length > 0;
+}
+
+/** Maps a marker span to fold lines, keeping same-line leading/trailing code visible. */
+export function spanToFoldingRange(
+  document: vscode.TextDocument,
+  span: { start: number; end: number },
+): vscode.FoldingRange | undefined {
+  const startLine = document.positionAt(span.start).line;
+  const endLine = document.positionAt(Math.max(span.start, span.end - 1)).line;
+
+  let foldStartLine = startLine;
+  let foldEndLine = endLine;
+
+  if (hasNonWhitespaceBefore(document, span.start)) {
+    foldStartLine = startLine + 1;
+  }
+
+  if (hasNonWhitespaceAfter(document, span.end)) {
+    foldEndLine = endLine - 1;
+  }
+
+  if (foldStartLine > foldEndLine) {
+    return undefined;
+  }
+
+  return new vscode.FoldingRange(
+    foldStartLine,
+    foldEndLine,
+    vscode.FoldingRangeKind.Region,
+  );
+}

--- a/tools/vscode_extension/src/rangeUtils.ts
+++ b/tools/vscode_extension/src/rangeUtils.ts
@@ -69,7 +69,7 @@ function hasNonWhitespaceAfter(
 /** Maps a marker span to fold lines, keeping same-line leading/trailing code visible. */
 export function spanToFoldingRange(
   document: vscode.TextDocument,
-  span: { start: number; end: number },
+  span: { start: number; end: number; endMarkerStart?: number },
 ): vscode.FoldingRange | undefined {
   const startLine = document.positionAt(span.start).line;
   const endLine = document.positionAt(Math.max(span.start, span.end - 1)).line;
@@ -81,7 +81,11 @@ export function spanToFoldingRange(
     foldStartLine = startLine + 1;
   }
 
-  if (hasNonWhitespaceAfter(document, span.end)) {
+  const endMarkerStart = span.endMarkerStart ?? span.end;
+  if (
+    hasNonWhitespaceBefore(document, endMarkerStart) ||
+    hasNonWhitespaceAfter(document, span.end)
+  ) {
     foldEndLine = endLine - 1;
   }
 

--- a/tools/vscode_extension/src/rangeUtils.ts
+++ b/tools/vscode_extension/src/rangeUtils.ts
@@ -89,7 +89,7 @@ export function spanToFoldingRange(
     foldEndLine = endLine - 1;
   }
 
-  if (foldStartLine > foldEndLine) {
+  if (foldStartLine >= foldEndLine) {
     return undefined;
   }
 

--- a/tools/vscode_extension/src/removeHighlighting.ts
+++ b/tools/vscode_extension/src/removeHighlighting.ts
@@ -1,35 +1,16 @@
 import * as vscode from 'vscode';
 
+import { findPairedBlockInteriors } from './annotationBlockPairing';
+import {
+  DROP_MARKER_PATTERN,
+  DROP_MARKER_SETS,
+  REMOVE_BOUNDARY_MARKER_PATTERN,
+  REMOVE_MARKER_SETS,
+} from './annotationMarkerSets';
 import { type AnnotationConfig } from './annotationConfig';
 import { collectRegexMatches } from './markerScanning';
 import { interiorsToRanges } from './rangeUtils';
 import { isSupportedBrickFile } from './supportedFiles';
-
-type MarkerKind = 'start' | 'end';
-
-interface MarkerMatch {
-  kind: MarkerKind;
-  offset: number;
-  length: number;
-}
-
-interface MarkerSet {
-  start: RegExp;
-  end: RegExp;
-}
-
-const REMOVE_MARKER_SETS: MarkerSet[] = [
-  { start: /\/\*(?:x-)?remove-start\*\//g, end: /\/\*remove-end(?:-x)?\*\//g },
-  { start: /#(?:x-)?remove-start#/g, end: /#remove-end(?:-x)?#/g },
-  { start: /<!--(?:x-)?remove-start-->/g, end: /<!--remove-end(?:-x)?-->/g },
-];
-
-const DROP_MARKER_SETS = [/\/\*drop\*\//g, /#drop#/g, /<!--drop-->/g];
-
-const REMOVE_BOUNDARY_MARKER_PATTERN =
-  /\/\*(?:x-)?remove-start\*\/|\/\*remove-end(?:-x)?\*\/|#(?:x-)?remove-start#|#remove-end(?:-x)?#|<!--(?:x-)?remove-start-->|<!--remove-end(?:-x)?-->/g;
-
-const DROP_MARKER_PATTERN = /\/\*drop\*\/|#drop#|<!--drop-->/g;
 
 let markerDecoration = vscode.window.createTextEditorDecorationType({});
 let contentDecoration = vscode.window.createTextEditorDecorationType({});
@@ -54,35 +35,6 @@ function ensureDecorations(config: AnnotationConfig): void {
   prevMarker.dispose();
   prevContent.dispose();
   appliedConfigKey = key;
-}
-
-function collectMarkers(text: string, pattern: RegExp, kind: MarkerKind): MarkerMatch[] {
-  return collectRegexMatches(text, pattern).map((m) => ({ ...m, kind }));
-}
-
-function findRemoveBlockInteriors(text: string): Array<{ start: number; end: number }> {
-  const interiors: Array<{ start: number; end: number }> = [];
-
-  for (const markerSet of REMOVE_MARKER_SETS) {
-    const markers = [
-      ...collectMarkers(text, markerSet.start, 'start'),
-      ...collectMarkers(text, markerSet.end, 'end'),
-    ].sort((a, b) => a.offset - b.offset);
-
-    const stack: MarkerMatch[] = [];
-    for (const marker of markers) {
-      if (marker.kind === 'start') { stack.push(marker); continue; }
-      if (stack.length === 0) continue;
-      const startMarker = stack.pop()!;
-      const interiorStart = startMarker.offset + startMarker.length;
-      const interiorEnd = marker.offset;
-      if (interiorEnd > interiorStart) {
-        interiors.push({ start: interiorStart, end: interiorEnd });
-      }
-    }
-  }
-
-  return interiors;
 }
 
 function findDropBlockInteriors(text: string): Array<{ start: number; end: number }> {
@@ -140,7 +92,7 @@ export function refreshRemoveHighlights(
   editor.setDecorations(
     contentDecoration,
     interiorsToRanges(editor.document, [
-      ...findRemoveBlockInteriors(text),
+      ...findPairedBlockInteriors(text, REMOVE_MARKER_SETS),
       ...findDropBlockInteriors(text),
     ]),
   );


### PR DESCRIPTION
## Overview
- add a `FoldingRangeProvider` that collapses brick generator annotation blocks in supported reference files
- fold `remove-start/end` (including `x-` and `-x` variants), `replace-start/end`, and matching `partial v/^` blocks across Dart, shell, and HTML comment flavors
- extract shared start/end block pairing utilities and marker regex sets so folding and remove highlighting reuse the same detection logic
- shrink fold ranges on marker lines that also carry code so same-line leading and trailing content stays visible when a block is collapsed