### PR TITLE
feat(vscode-ext): add diagnostic validation for annotation pairs

### DIFF
--- a/tools/brick_generator/lib/src/annotation_validator.dart
+++ b/tools/brick_generator/lib/src/annotation_validator.dart
@@ -243,6 +243,15 @@ class AnnotationValidator {
                 stack.removeLast();
               }
               expecting = _ReplaceMarkerKind.start;
+            } else if (marker.kind == _ReplaceMarkerKind.withMarker) {
+              issues.add(
+                _issue(
+                  content,
+                  marker.offset,
+                  'Duplicate with marker in replace block (${markerSet.flavor})',
+                ),
+              );
+              expecting = _ReplaceMarkerKind.end;
             } else {
               issues.add(
                 _issue(
@@ -251,12 +260,8 @@ class AnnotationValidator {
                   'replace-start block is missing replace-end (${markerSet.flavor})',
                 ),
               );
-              if (marker.kind == _ReplaceMarkerKind.start) {
-                stack.add(marker.offset);
-                expecting = _ReplaceMarkerKind.withMarker;
-              } else {
-                expecting = _ReplaceMarkerKind.end;
-              }
+              stack.add(marker.offset);
+              expecting = _ReplaceMarkerKind.withMarker;
             }
         }
       }

--- a/tools/brick_generator/test/src/annotation_validator_test.dart
+++ b/tools/brick_generator/test/src/annotation_validator_test.dart
@@ -105,6 +105,23 @@ old
         expect(validator.validateContent(content), isEmpty);
       });
 
+      test('detects duplicate with marker in replace block', () {
+        const content = '''
+/*replace-start*/
+old
+/*with*/
+/*with*/
+new
+/*replace-end*/
+''';
+        final issues = validator.validateContent(content);
+        expect(issues, isNotEmpty);
+        expect(
+          issues.map((i) => i.message),
+          anyElement(contains('Duplicate with marker')),
+        );
+      });
+
       test('detects partial name mismatch', () {
         const content =
             '/*partial v foo*/payload/*partial ^ bar*/';

--- a/tools/vscode_extension/src/annotationDiagnostics.ts
+++ b/tools/vscode_extension/src/annotationDiagnostics.ts
@@ -13,7 +13,7 @@ function issueToDiagnostic(
   issue: AnnotationIssue,
 ): vscode.Diagnostic {
   const start = document.positionAt(issue.offset);
-  const end = start.translate(0, 1);
+  const end = document.positionAt(issue.offset + issue.length);
   const diagnostic = new vscode.Diagnostic(
     new vscode.Range(start, end),
     issue.message,

--- a/tools/vscode_extension/src/annotationDiagnostics.ts
+++ b/tools/vscode_extension/src/annotationDiagnostics.ts
@@ -1,0 +1,62 @@
+import * as vscode from 'vscode';
+
+import {
+  validateAnnotationContent,
+  type AnnotationIssue,
+} from './annotationValidator';
+import { isSupportedBrickFile } from './supportedFiles';
+
+const DIAGNOSTIC_SOURCE = 'brick-generator';
+
+function issueToDiagnostic(
+  document: vscode.TextDocument,
+  issue: AnnotationIssue,
+): vscode.Diagnostic {
+  const start = document.positionAt(issue.offset);
+  const end = start.translate(0, 1);
+  const diagnostic = new vscode.Diagnostic(
+    new vscode.Range(start, end),
+    issue.message,
+    vscode.DiagnosticSeverity.Error,
+  );
+  diagnostic.source = DIAGNOSTIC_SOURCE;
+  return diagnostic;
+}
+
+function validateDocument(document: vscode.TextDocument): vscode.Diagnostic[] {
+  if (!isSupportedBrickFile(document)) {
+    return [];
+  }
+
+  return validateAnnotationContent(document.getText()).map((issue) =>
+    issueToDiagnostic(document, issue),
+  );
+}
+
+export function registerAnnotationDiagnostics(
+  context: vscode.ExtensionContext,
+): void {
+  const collection = vscode.languages.createDiagnosticCollection(DIAGNOSTIC_SOURCE);
+
+  const refresh = (document: vscode.TextDocument): void => {
+    if (document.uri.scheme !== 'file') {
+      return;
+    }
+    collection.set(document.uri, validateDocument(document));
+  };
+
+  const clear = (document: vscode.TextDocument): void => {
+    collection.delete(document.uri);
+  };
+
+  for (const editor of vscode.window.visibleTextEditors) {
+    refresh(editor.document);
+  }
+
+  context.subscriptions.push(
+    collection,
+    vscode.workspace.onDidOpenTextDocument(refresh),
+    vscode.workspace.onDidChangeTextDocument((event) => refresh(event.document)),
+    vscode.workspace.onDidCloseTextDocument(clear),
+  );
+}

--- a/tools/vscode_extension/src/annotationMarkerSets.ts
+++ b/tools/vscode_extension/src/annotationMarkerSets.ts
@@ -3,17 +3,49 @@ import {
   type StartEndMarkerSet,
 } from './annotationBlockPairing';
 
+export const COMMENT_FLAVORS = ['/* */', '# #', '<!-- -->'] as const;
+
+export type CommentFlavor = (typeof COMMENT_FLAVORS)[number];
+
+export interface ReplaceWithMarkerSet {
+  start: RegExp;
+  withMarker: RegExp;
+  end: RegExp;
+}
+
 export const REMOVE_MARKER_SETS: StartEndMarkerSet[] = [
   { start: /\/\*(?:x-)?remove-start\*\//g, end: /\/\*remove-end(?:-x)?\*\//g },
   { start: /#(?:x-)?remove-start#/g, end: /#remove-end(?:-x)?#/g },
   { start: /<!--(?:x-)?remove-start-->/g, end: /<!--remove-end(?:-x)?-->/g },
 ];
 
-export const REPLACE_MARKER_SETS: StartEndMarkerSet[] = [
-  { start: /\/\*replace-start\*\//g, end: /\/\*replace-end\*\//g },
-  { start: /#replace-start#/g, end: /#replace-end#/g },
-  { start: /<!--replace-start-->/g, end: /<!--replace-end-->/g },
+export const INSERT_MARKER_SETS: StartEndMarkerSet[] = [
+  { start: /\/\*insert-start\*\//g, end: /\/\*insert-end\*\//g },
+  { start: /#insert-start#/g, end: /#insert-end#/g },
+  { start: /<!--insert-start-->/g, end: /<!--insert-end-->/g },
 ];
+
+export const REPLACE_WITH_MARKER_SETS: ReplaceWithMarkerSet[] = [
+  {
+    start: /\/\*replace-start\*\//g,
+    withMarker: /\/\*with(?: +i\d+)?\*\//g,
+    end: /\/\*replace-end\*\//g,
+  },
+  {
+    start: /#replace-start#/g,
+    withMarker: /#with(?: +i\d+)?#/g,
+    end: /#replace-end#/g,
+  },
+  {
+    start: /<!--replace-start-->/g,
+    withMarker: /<!--with(?: +i\d+)?-->/g,
+    end: /<!--replace-end-->/g,
+  },
+];
+
+export const REPLACE_MARKER_SETS: StartEndMarkerSet[] = REPLACE_WITH_MARKER_SETS.map(
+  ({ start, end }) => ({ start, end }),
+);
 
 export const PARTIAL_MARKER_SETS: NamedStartEndMarkerSet[] = [
   { start: /\/\*partial v ([^*]+)\*\//g, end: /\/\*partial \^ ([^*]+)\*\//g },
@@ -23,6 +55,18 @@ export const PARTIAL_MARKER_SETS: NamedStartEndMarkerSet[] = [
 
 export const REMOVE_BOUNDARY_MARKER_PATTERN =
   /\/\*(?:x-)?remove-start\*\/|\/\*remove-end(?:-x)?\*\/|#(?:x-)?remove-start#|#remove-end(?:-x)?#|<!--(?:x-)?remove-start-->|<!--remove-end(?:-x)?-->/g;
+
+export const INSERT_BOUNDARY_MARKER_PATTERN =
+  /\/\*insert-start\*\/|\/\*insert-end\*\/|#insert-start#|#insert-end#|<!--insert-start-->|<!--insert-end-->/g;
+
+export const REPLACE_START_END_MARKER_PATTERN =
+  /\/\*replace-start\*\/|\/\*replace-end\*\/|#replace-start#|#replace-end#|<!--replace-start-->|<!--replace-end-->/g;
+
+export const WITH_MARKER_PATTERN =
+  /\/\*with(?: +i\d+)?\*\/|#with(?: +i\d+)?#|<!--with(?: +i\d+)?-->/g;
+
+export const PARTIAL_BOUNDARY_MARKER_PATTERN =
+  /\/\*partial [v^] [^*]+\*\/|#partial [v^] [^#]+#|<!--partial [v^] .+?-->/g;
 
 export const DROP_MARKER_SETS = [/\/\*drop\*\//g, /#drop#/g, /<!--drop-->/g];
 

--- a/tools/vscode_extension/src/annotationValidator.ts
+++ b/tools/vscode_extension/src/annotationValidator.ts
@@ -1,0 +1,415 @@
+import { collectRegexMatches } from './markerScanning';
+
+export interface AnnotationIssue {
+  offset: number;
+  line: number;
+  column: number;
+  message: string;
+}
+
+interface MarkerSet {
+  flavor: string;
+  blockName: string;
+  start: RegExp;
+  end: RegExp;
+}
+
+interface ReplaceMarkerSet {
+  flavor: string;
+  start: RegExp;
+  withMarker: RegExp;
+  end: RegExp;
+}
+
+interface PartialMarkerSet {
+  flavor: string;
+  start: RegExp;
+  end: RegExp;
+}
+
+type MarkerKind = 'start' | 'end';
+
+interface Marker {
+  kind: MarkerKind;
+  offset: number;
+}
+
+type ReplaceMarkerKind = 'start' | 'withMarker' | 'end';
+
+interface ReplaceMarker {
+  kind: ReplaceMarkerKind;
+  offset: number;
+}
+
+type PartialMarkerKind = 'start' | 'end';
+
+interface PartialMarker {
+  kind: PartialMarkerKind;
+  offset: number;
+  name: string;
+}
+
+const REMOVE_MARKER_SETS: MarkerSet[] = [
+  {
+    flavor: '/* */',
+    blockName: 'remove',
+    start: /\/\*(?:x-)?remove-start\*\//g,
+    end: /\/\*remove-end(?:-x)?\*\//g,
+  },
+  {
+    flavor: '# #',
+    blockName: 'remove',
+    start: /#(?:x-)?remove-start#/g,
+    end: /#remove-end(?:-x)?#/g,
+  },
+  {
+    flavor: '<!-- -->',
+    blockName: 'remove',
+    start: /<!--(?:x-)?remove-start-->/g,
+    end: /<!--remove-end(?:-x)?-->/g,
+  },
+];
+
+const INSERT_MARKER_SETS: MarkerSet[] = [
+  {
+    flavor: '/* */',
+    blockName: 'insert',
+    start: /\/\*insert-start\*\//g,
+    end: /\/\*insert-end\*\//g,
+  },
+  {
+    flavor: '# #',
+    blockName: 'insert',
+    start: /#insert-start#/g,
+    end: /#insert-end#/g,
+  },
+  {
+    flavor: '<!-- -->',
+    blockName: 'insert',
+    start: /<!--insert-start-->/g,
+    end: /<!--insert-end-->/g,
+  },
+];
+
+const REPLACE_MARKER_SETS: ReplaceMarkerSet[] = [
+  {
+    flavor: '/* */',
+    start: /\/\*replace-start\*\//g,
+    withMarker: /\/\*with(?: +i\d+)?\*\//g,
+    end: /\/\*replace-end\*\//g,
+  },
+  {
+    flavor: '# #',
+    start: /#replace-start#/g,
+    withMarker: /#with(?: +i\d+)?#/g,
+    end: /#replace-end#/g,
+  },
+  {
+    flavor: '<!-- -->',
+    start: /<!--replace-start-->/g,
+    withMarker: /<!--with(?: +i\d+)?-->/g,
+    end: /<!--replace-end-->/g,
+  },
+];
+
+const PARTIAL_MARKER_SETS: PartialMarkerSet[] = [
+  {
+    flavor: '/* */',
+    start: /\/\*partial v ([^*]+)\*\//g,
+    end: /\/\*partial \^ ([^*]+)\*\//g,
+  },
+  {
+    flavor: '# #',
+    start: /#partial v ([^#]+)#/g,
+    end: /#partial \^ ([^#]+)#/g,
+  },
+  {
+    flavor: '<!-- -->',
+    start: /<!--partial v (.+?)-->/g,
+    end: /<!--partial \^ (.+?)-->/g,
+  },
+];
+
+function replaceMarkerLabel(kind: ReplaceMarkerKind): string {
+  switch (kind) {
+    case 'start':
+      return 'replace-start';
+    case 'withMarker':
+      return 'with';
+    case 'end':
+      return 'replace-end';
+  }
+}
+
+function lineAt(content: string, offset: number): number {
+  return content.slice(0, offset).split('\n').length;
+}
+
+function columnAt(content: string, offset: number): number {
+  const lastNewline = content.lastIndexOf('\n', offset === 0 ? 0 : offset - 1);
+  return offset - lastNewline;
+}
+
+function issue(content: string, offset: number, message: string): AnnotationIssue {
+  return {
+    offset,
+    line: lineAt(content, offset),
+    column: columnAt(content, offset),
+    message,
+  };
+}
+
+function collectMarkers(
+  text: string,
+  pattern: RegExp,
+  kind: MarkerKind,
+): Marker[] {
+  return collectRegexMatches(text, pattern).map((match) => ({
+    kind,
+    offset: match.offset,
+  }));
+}
+
+function validatePairedMarkers(
+  content: string,
+  markerSets: MarkerSet[],
+): AnnotationIssue[] {
+  const issues: AnnotationIssue[] = [];
+
+  for (const markerSet of markerSets) {
+    const markers = [
+      ...collectMarkers(content, markerSet.start, 'start'),
+      ...collectMarkers(content, markerSet.end, 'end'),
+    ].sort((a, b) => a.offset - b.offset);
+
+    const stack: Marker[] = [];
+    for (const marker of markers) {
+      if (marker.kind === 'start') {
+        stack.push(marker);
+        continue;
+      }
+
+      if (stack.length === 0) {
+        issues.push(
+          issue(
+            content,
+            marker.offset,
+            `Unmatched ${markerSet.blockName}-end marker (${markerSet.flavor})`,
+          ),
+        );
+        continue;
+      }
+
+      stack.pop();
+    }
+
+    for (const unmatched of stack) {
+      issues.push(
+        issue(
+          content,
+          unmatched.offset,
+          `Unmatched ${markerSet.blockName}-start marker (${markerSet.flavor})`,
+        ),
+      );
+    }
+  }
+
+  return issues;
+}
+
+function collectReplaceMarkers(
+  text: string,
+  pattern: RegExp,
+  kind: ReplaceMarkerKind,
+): ReplaceMarker[] {
+  return collectRegexMatches(text, pattern).map((match) => ({
+    kind,
+    offset: match.offset,
+  }));
+}
+
+function validateReplaceBlocks(content: string): AnnotationIssue[] {
+  const issues: AnnotationIssue[] = [];
+
+  for (const markerSet of REPLACE_MARKER_SETS) {
+    const markers = [
+      ...collectReplaceMarkers(content, markerSet.start, 'start'),
+      ...collectReplaceMarkers(content, markerSet.withMarker, 'withMarker'),
+      ...collectReplaceMarkers(content, markerSet.end, 'end'),
+    ].sort((a, b) => a.offset - b.offset);
+
+    let expecting: ReplaceMarkerKind = 'start';
+    const stack: number[] = [];
+
+    for (const marker of markers) {
+      switch (expecting) {
+        case 'start':
+          if (marker.kind === 'start') {
+            stack.push(marker.offset);
+            expecting = 'withMarker';
+          } else {
+            issues.push(
+              issue(
+                content,
+                marker.offset,
+                `Unexpected ${replaceMarkerLabel(marker.kind)} before replace-start (${markerSet.flavor})`,
+              ),
+            );
+          }
+          break;
+        case 'withMarker':
+          if (marker.kind === 'withMarker') {
+            expecting = 'end';
+          } else if (marker.kind === 'start') {
+            issues.push(
+              issue(
+                content,
+                marker.offset,
+                `Nested replace-start is not supported (${markerSet.flavor})`,
+              ),
+            );
+          } else {
+            issues.push(
+              issue(
+                content,
+                marker.offset,
+                `replace-end without a matching with marker (${markerSet.flavor})`,
+              ),
+            );
+            expecting = 'start';
+            stack.length = 0;
+          }
+          break;
+        case 'end':
+          if (marker.kind === 'end') {
+            if (stack.length === 0) {
+              issues.push(
+                issue(
+                  content,
+                  marker.offset,
+                  `Unmatched replace-end marker (${markerSet.flavor})`,
+                ),
+              );
+            } else {
+              stack.pop();
+            }
+            expecting = 'start';
+          } else {
+            issues.push(
+              issue(
+                content,
+                marker.offset,
+                `replace-start block is missing replace-end (${markerSet.flavor})`,
+              ),
+            );
+            if (marker.kind === 'start') {
+              stack.push(marker.offset);
+              expecting = 'withMarker';
+            } else {
+              expecting = 'end';
+            }
+          }
+          break;
+      }
+    }
+
+    for (const startOffset of stack) {
+      issues.push(
+        issue(
+          content,
+          startOffset,
+          `Unmatched replace-start marker (${markerSet.flavor})`,
+        ),
+      );
+    }
+  }
+
+  return issues;
+}
+
+function collectNamedMarkers(
+  text: string,
+  pattern: RegExp,
+  kind: PartialMarkerKind,
+): PartialMarker[] {
+  const markers: PartialMarker[] = [];
+  const expression = new RegExp(pattern.source, pattern.flags);
+
+  for (const match of text.matchAll(expression)) {
+    const offset = match.index;
+    if (offset === undefined) {
+      continue;
+    }
+    markers.push({
+      kind,
+      offset,
+      name: match[1] ?? '',
+    });
+  }
+
+  return markers;
+}
+
+function validatePartialBlocks(content: string): AnnotationIssue[] {
+  const issues: AnnotationIssue[] = [];
+
+  for (const markerSet of PARTIAL_MARKER_SETS) {
+    const markers = [
+      ...collectNamedMarkers(content, markerSet.start, 'start'),
+      ...collectNamedMarkers(content, markerSet.end, 'end'),
+    ].sort((a, b) => a.offset - b.offset);
+
+    const stack: PartialMarker[] = [];
+    for (const marker of markers) {
+      if (marker.kind === 'start') {
+        stack.push(marker);
+        continue;
+      }
+
+      if (stack.length === 0) {
+        issues.push(
+          issue(
+            content,
+            marker.offset,
+            `Unmatched partial ^ marker for "${marker.name}" (${markerSet.flavor})`,
+          ),
+        );
+        continue;
+      }
+
+      const start = stack.pop()!;
+      if (start.name !== marker.name) {
+        issues.push(
+          issue(
+            content,
+            marker.offset,
+            `partial ^ name "${marker.name}" does not match `
+              + `partial v name "${start.name}" (${markerSet.flavor})`,
+          ),
+        );
+      }
+    }
+
+    for (const unmatched of stack) {
+      issues.push(
+        issue(
+          content,
+          unmatched.offset,
+          `Unmatched partial v marker for "${unmatched.name}" (${markerSet.flavor})`,
+        ),
+      );
+    }
+  }
+
+  return issues;
+}
+
+/** Validates brick-generator annotation markers in file contents. */
+export function validateAnnotationContent(content: string): AnnotationIssue[] {
+  return [
+    ...validatePairedMarkers(content, REMOVE_MARKER_SETS),
+    ...validatePairedMarkers(content, INSERT_MARKER_SETS),
+    ...validateReplaceBlocks(content),
+    ...validatePartialBlocks(content),
+  ];
+}

--- a/tools/vscode_extension/src/annotationValidator.ts
+++ b/tools/vscode_extension/src/annotationValidator.ts
@@ -1,3 +1,11 @@
+import {
+  COMMENT_FLAVORS,
+  INSERT_MARKER_SETS,
+  PARTIAL_MARKER_SETS,
+  REMOVE_MARKER_SETS,
+  REPLACE_WITH_MARKER_SETS,
+  type CommentFlavor,
+} from './annotationMarkerSets';
 import { collectRegexMatches } from './markerScanning';
 
 export interface AnnotationIssue {
@@ -6,26 +14,6 @@ export interface AnnotationIssue {
   line: number;
   column: number;
   message: string;
-}
-
-interface MarkerSet {
-  flavor: string;
-  blockName: string;
-  start: RegExp;
-  end: RegExp;
-}
-
-interface ReplaceMarkerSet {
-  flavor: string;
-  start: RegExp;
-  withMarker: RegExp;
-  end: RegExp;
-}
-
-interface PartialMarkerSet {
-  flavor: string;
-  start: RegExp;
-  end: RegExp;
 }
 
 type MarkerKind = 'start' | 'end';
@@ -53,86 +41,54 @@ interface PartialMarker {
   name: string;
 }
 
-const REMOVE_MARKER_SETS: MarkerSet[] = [
-  {
-    flavor: '/* */',
-    blockName: 'remove',
-    start: /\/\*(?:x-)?remove-start\*\//g,
-    end: /\/\*remove-end(?:-x)?\*\//g,
-  },
-  {
-    flavor: '# #',
-    blockName: 'remove',
-    start: /#(?:x-)?remove-start#/g,
-    end: /#remove-end(?:-x)?#/g,
-  },
-  {
-    flavor: '<!-- -->',
-    blockName: 'remove',
-    start: /<!--(?:x-)?remove-start-->/g,
-    end: /<!--remove-end(?:-x)?-->/g,
-  },
-];
+interface FlavoredMarkerSet {
+  flavor: CommentFlavor;
+  blockName: string;
+  start: RegExp;
+  end: RegExp;
+}
 
-const INSERT_MARKER_SETS: MarkerSet[] = [
-  {
-    flavor: '/* */',
-    blockName: 'insert',
-    start: /\/\*insert-start\*\//g,
-    end: /\/\*insert-end\*\//g,
-  },
-  {
-    flavor: '# #',
-    blockName: 'insert',
-    start: /#insert-start#/g,
-    end: /#insert-end#/g,
-  },
-  {
-    flavor: '<!-- -->',
-    blockName: 'insert',
-    start: /<!--insert-start-->/g,
-    end: /<!--insert-end-->/g,
-  },
-];
+interface FlavoredReplaceMarkerSet {
+  flavor: CommentFlavor;
+  start: RegExp;
+  withMarker: RegExp;
+  end: RegExp;
+}
 
-const REPLACE_MARKER_SETS: ReplaceMarkerSet[] = [
-  {
-    flavor: '/* */',
-    start: /\/\*replace-start\*\//g,
-    withMarker: /\/\*with(?: +i\d+)?\*\//g,
-    end: /\/\*replace-end\*\//g,
-  },
-  {
-    flavor: '# #',
-    start: /#replace-start#/g,
-    withMarker: /#with(?: +i\d+)?#/g,
-    end: /#replace-end#/g,
-  },
-  {
-    flavor: '<!-- -->',
-    start: /<!--replace-start-->/g,
-    withMarker: /<!--with(?: +i\d+)?-->/g,
-    end: /<!--replace-end-->/g,
-  },
-];
+interface FlavoredPartialMarkerSet {
+  flavor: CommentFlavor;
+  start: RegExp;
+  end: RegExp;
+}
 
-const PARTIAL_MARKER_SETS: PartialMarkerSet[] = [
-  {
-    flavor: '/* */',
-    start: /\/\*partial v ([^*]+)\*\//g,
-    end: /\/\*partial \^ ([^*]+)\*\//g,
-  },
-  {
-    flavor: '# #',
-    start: /#partial v ([^#]+)#/g,
-    end: /#partial \^ ([^#]+)#/g,
-  },
-  {
-    flavor: '<!-- -->',
-    start: /<!--partial v (.+?)-->/g,
-    end: /<!--partial \^ (.+?)-->/g,
-  },
-];
+function withBlockName(
+  sets: Array<{ start: RegExp; end: RegExp }>,
+  blockName: string,
+): FlavoredMarkerSet[] {
+  return sets.map((set, index) => ({
+    ...set,
+    flavor: COMMENT_FLAVORS[index],
+    blockName,
+  }));
+}
+
+function withFlavor<T extends { start: RegExp; end: RegExp }>(
+  sets: T[],
+): Array<T & { flavor: CommentFlavor }> {
+  return sets.map((set, index) => ({
+    ...set,
+    flavor: COMMENT_FLAVORS[index],
+  }));
+}
+
+const FLAVORED_REMOVE_MARKER_SETS = withBlockName(REMOVE_MARKER_SETS, 'remove');
+const FLAVORED_INSERT_MARKER_SETS = withBlockName(INSERT_MARKER_SETS, 'insert');
+const FLAVORED_REPLACE_MARKER_SETS: FlavoredReplaceMarkerSet[] = withFlavor(
+  REPLACE_WITH_MARKER_SETS,
+);
+const FLAVORED_PARTIAL_MARKER_SETS: FlavoredPartialMarkerSet[] = withFlavor(
+  PARTIAL_MARKER_SETS,
+);
 
 function replaceMarkerLabel(kind: ReplaceMarkerKind): string {
   switch (kind) {
@@ -183,7 +139,7 @@ function collectMarkers(
 
 function validatePairedMarkers(
   content: string,
-  markerSets: MarkerSet[],
+  markerSets: FlavoredMarkerSet[],
 ): AnnotationIssue[] {
   const issues: AnnotationIssue[] = [];
 
@@ -245,7 +201,7 @@ function collectReplaceMarkers(
 function validateReplaceBlocks(content: string): AnnotationIssue[] {
   const issues: AnnotationIssue[] = [];
 
-  for (const markerSet of REPLACE_MARKER_SETS) {
+  for (const markerSet of FLAVORED_REPLACE_MARKER_SETS) {
     const markers = [
       ...collectReplaceMarkers(content, markerSet.start, 'start'),
       ...collectReplaceMarkers(content, markerSet.withMarker, 'withMarker'),
@@ -380,7 +336,7 @@ function collectNamedMarkers(
 function validatePartialBlocks(content: string): AnnotationIssue[] {
   const issues: AnnotationIssue[] = [];
 
-  for (const markerSet of PARTIAL_MARKER_SETS) {
+  for (const markerSet of FLAVORED_PARTIAL_MARKER_SETS) {
     const markers = [
       ...collectNamedMarkers(content, markerSet.start, 'start'),
       ...collectNamedMarkers(content, markerSet.end, 'end'),
@@ -437,8 +393,8 @@ function validatePartialBlocks(content: string): AnnotationIssue[] {
 /** Validates brick-generator annotation markers in file contents. */
 export function validateAnnotationContent(content: string): AnnotationIssue[] {
   return [
-    ...validatePairedMarkers(content, REMOVE_MARKER_SETS),
-    ...validatePairedMarkers(content, INSERT_MARKER_SETS),
+    ...validatePairedMarkers(content, FLAVORED_REMOVE_MARKER_SETS),
+    ...validatePairedMarkers(content, FLAVORED_INSERT_MARKER_SETS),
     ...validateReplaceBlocks(content),
     ...validatePartialBlocks(content),
   ];

--- a/tools/vscode_extension/src/annotationValidator.ts
+++ b/tools/vscode_extension/src/annotationValidator.ts
@@ -2,6 +2,7 @@ import { collectRegexMatches } from './markerScanning';
 
 export interface AnnotationIssue {
   offset: number;
+  length: number;
   line: number;
   column: number;
   message: string;
@@ -32,6 +33,7 @@ type MarkerKind = 'start' | 'end';
 interface Marker {
   kind: MarkerKind;
   offset: number;
+  length: number;
 }
 
 type ReplaceMarkerKind = 'start' | 'withMarker' | 'end';
@@ -39,6 +41,7 @@ type ReplaceMarkerKind = 'start' | 'withMarker' | 'end';
 interface ReplaceMarker {
   kind: ReplaceMarkerKind;
   offset: number;
+  length: number;
 }
 
 type PartialMarkerKind = 'start' | 'end';
@@ -46,6 +49,7 @@ type PartialMarkerKind = 'start' | 'end';
 interface PartialMarker {
   kind: PartialMarkerKind;
   offset: number;
+  length: number;
   name: string;
 }
 
@@ -150,9 +154,15 @@ function columnAt(content: string, offset: number): number {
   return offset - lastNewline;
 }
 
-function issue(content: string, offset: number, message: string): AnnotationIssue {
+function issue(
+  content: string,
+  offset: number,
+  length: number,
+  message: string,
+): AnnotationIssue {
   return {
     offset,
+    length,
     line: lineAt(content, offset),
     column: columnAt(content, offset),
     message,
@@ -167,6 +177,7 @@ function collectMarkers(
   return collectRegexMatches(text, pattern).map((match) => ({
     kind,
     offset: match.offset,
+    length: match.length,
   }));
 }
 
@@ -194,6 +205,7 @@ function validatePairedMarkers(
           issue(
             content,
             marker.offset,
+            marker.length,
             `Unmatched ${markerSet.blockName}-end marker (${markerSet.flavor})`,
           ),
         );
@@ -208,6 +220,7 @@ function validatePairedMarkers(
         issue(
           content,
           unmatched.offset,
+          unmatched.length,
           `Unmatched ${markerSet.blockName}-start marker (${markerSet.flavor})`,
         ),
       );
@@ -225,6 +238,7 @@ function collectReplaceMarkers(
   return collectRegexMatches(text, pattern).map((match) => ({
     kind,
     offset: match.offset,
+    length: match.length,
   }));
 }
 
@@ -239,19 +253,20 @@ function validateReplaceBlocks(content: string): AnnotationIssue[] {
     ].sort((a, b) => a.offset - b.offset);
 
     let expecting: ReplaceMarkerKind = 'start';
-    const stack: number[] = [];
+    const stack: Array<{ offset: number; length: number }> = [];
 
     for (const marker of markers) {
       switch (expecting) {
         case 'start':
           if (marker.kind === 'start') {
-            stack.push(marker.offset);
+            stack.push({ offset: marker.offset, length: marker.length });
             expecting = 'withMarker';
           } else {
             issues.push(
               issue(
                 content,
                 marker.offset,
+                marker.length,
                 `Unexpected ${replaceMarkerLabel(marker.kind)} before replace-start (${markerSet.flavor})`,
               ),
             );
@@ -265,6 +280,7 @@ function validateReplaceBlocks(content: string): AnnotationIssue[] {
               issue(
                 content,
                 marker.offset,
+                marker.length,
                 `Nested replace-start is not supported (${markerSet.flavor})`,
               ),
             );
@@ -273,6 +289,7 @@ function validateReplaceBlocks(content: string): AnnotationIssue[] {
               issue(
                 content,
                 marker.offset,
+                marker.length,
                 `replace-end without a matching with marker (${markerSet.flavor})`,
               ),
             );
@@ -287,6 +304,7 @@ function validateReplaceBlocks(content: string): AnnotationIssue[] {
                 issue(
                   content,
                   marker.offset,
+                  marker.length,
                   `Unmatched replace-end marker (${markerSet.flavor})`,
                 ),
               );
@@ -299,11 +317,12 @@ function validateReplaceBlocks(content: string): AnnotationIssue[] {
               issue(
                 content,
                 marker.offset,
+                marker.length,
                 `replace-start block is missing replace-end (${markerSet.flavor})`,
               ),
             );
             if (marker.kind === 'start') {
-              stack.push(marker.offset);
+              stack.push({ offset: marker.offset, length: marker.length });
               expecting = 'withMarker';
             } else {
               expecting = 'end';
@@ -313,11 +332,12 @@ function validateReplaceBlocks(content: string): AnnotationIssue[] {
       }
     }
 
-    for (const startOffset of stack) {
+    for (const startMarker of stack) {
       issues.push(
         issue(
           content,
-          startOffset,
+          startMarker.offset,
+          startMarker.length,
           `Unmatched replace-start marker (${markerSet.flavor})`,
         ),
       );
@@ -343,6 +363,7 @@ function collectNamedMarkers(
     markers.push({
       kind,
       offset,
+      length: match[0].length,
       name: match[1] ?? '',
     });
   }
@@ -371,6 +392,7 @@ function validatePartialBlocks(content: string): AnnotationIssue[] {
           issue(
             content,
             marker.offset,
+            marker.length,
             `Unmatched partial ^ marker for "${marker.name}" (${markerSet.flavor})`,
           ),
         );
@@ -383,6 +405,7 @@ function validatePartialBlocks(content: string): AnnotationIssue[] {
           issue(
             content,
             marker.offset,
+            marker.length,
             `partial ^ name "${marker.name}" does not match `
               + `partial v name "${start.name}" (${markerSet.flavor})`,
           ),
@@ -395,6 +418,7 @@ function validatePartialBlocks(content: string): AnnotationIssue[] {
         issue(
           content,
           unmatched.offset,
+          unmatched.length,
           `Unmatched partial v marker for "${unmatched.name}" (${markerSet.flavor})`,
         ),
       );

--- a/tools/vscode_extension/src/annotationValidator.ts
+++ b/tools/vscode_extension/src/annotationValidator.ts
@@ -312,6 +312,16 @@ function validateReplaceBlocks(content: string): AnnotationIssue[] {
               stack.pop();
             }
             expecting = 'start';
+          } else if (marker.kind === 'withMarker') {
+            issues.push(
+              issue(
+                content,
+                marker.offset,
+                marker.length,
+                `Duplicate with marker in replace block (${markerSet.flavor})`,
+              ),
+            );
+            expecting = 'end';
           } else {
             issues.push(
               issue(
@@ -321,12 +331,8 @@ function validateReplaceBlocks(content: string): AnnotationIssue[] {
                 `replace-start block is missing replace-end (${markerSet.flavor})`,
               ),
             );
-            if (marker.kind === 'start') {
-              stack.push({ offset: marker.offset, length: marker.length });
-              expecting = 'withMarker';
-            } else {
-              expecting = 'end';
-            }
+            stack.push({ offset: marker.offset, length: marker.length });
+            expecting = 'withMarker';
           }
           break;
       }

--- a/tools/vscode_extension/src/extension.ts
+++ b/tools/vscode_extension/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { registerAnnotationDiagnostics } from './annotationDiagnostics';
 import { registerBlockFolding } from './blockFolding';
 import { registerBrickHighlighting } from './brickHighlighting';
 import { registerInsertHighlighting } from './insertHighlighting';
@@ -14,9 +15,10 @@ import { registerSpacingHighlighting } from './spacingHighlighting';
  *
  * Annotation syntax highlighting is contributed via TextMate grammar injection;
  * annotation regions are tinted programmatically so colors apply reliably inside
- * comment regions. Diagnostics and preview register here later.
+ * comment regions. Preview registers here later.
  */
 export function activate(context: vscode.ExtensionContext): void {
+  registerAnnotationDiagnostics(context);
   registerBlockFolding(context);
   registerRemoveHighlighting(context);
   registerReplaceHighlighting(context);

--- a/tools/vscode_extension/src/insertHighlighting.ts
+++ b/tools/vscode_extension/src/insertHighlighting.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { INSERT_BOUNDARY_MARKER_PATTERN, INSERT_MARKER_SETS } from './annotationMarkerSets';
 import { type AnnotationConfig } from './annotationConfig';
 import { collectRegexMatches } from './markerScanning';
 import { interiorsToRanges } from './rangeUtils';
@@ -12,15 +13,6 @@ interface MarkerMatch {
   offset: number;
   length: number;
 }
-
-const INSERT_MARKER_SETS = [
-  { start: /\/\*insert-start\*\//g, end: /\/\*insert-end\*\//g },
-  { start: /#insert-start#/g, end: /#insert-end#/g },
-  { start: /<!--insert-start-->/g, end: /<!--insert-end-->/g },
-];
-
-const INSERT_BOUNDARY_MARKER_PATTERN =
-  /\/\*insert-start\*\/|\/\*insert-end\*\/|#insert-start#|#insert-end#|<!--insert-start-->|<!--insert-end-->/g;
 
 let markerDecoration = vscode.window.createTextEditorDecorationType({});
 let contentDecoration = vscode.window.createTextEditorDecorationType({});

--- a/tools/vscode_extension/src/partialHighlighting.ts
+++ b/tools/vscode_extension/src/partialHighlighting.ts
@@ -1,5 +1,9 @@
 import * as vscode from 'vscode';
 
+import {
+  PARTIAL_BOUNDARY_MARKER_PATTERN,
+  PARTIAL_MARKER_SETS,
+} from './annotationMarkerSets';
 import { type AnnotationConfig } from './annotationConfig';
 import { interiorsToRanges } from './rangeUtils';
 import { isSupportedBrickFile } from './supportedFiles';
@@ -12,15 +16,6 @@ interface PartialMarker {
   length: number;
   name: string;
 }
-
-const PARTIAL_MARKER_SETS = [
-  { start: /\/\*partial v ([^*]+)\*\//g, end: /\/\*partial \^ ([^*]+)\*\//g },
-  { start: /#partial v ([^#]+)#/g, end: /#partial \^ ([^#]+)#/g },
-  { start: /<!--partial v (.+?)-->/g, end: /<!--partial \^ (.+?)-->/g },
-];
-
-const PARTIAL_BOUNDARY_MARKER_PATTERN =
-  /\/\*partial [v^] [^*]+\*\/|#partial [v^] [^#]+#|<!--partial [v^] .+?-->/g;
 
 let markerDecoration = vscode.window.createTextEditorDecorationType({});
 let payloadDecoration = vscode.window.createTextEditorDecorationType({});

--- a/tools/vscode_extension/src/replaceHighlighting.ts
+++ b/tools/vscode_extension/src/replaceHighlighting.ts
@@ -1,5 +1,10 @@
 import * as vscode from 'vscode';
 
+import {
+  REPLACE_START_END_MARKER_PATTERN,
+  REPLACE_WITH_MARKER_SETS,
+  WITH_MARKER_PATTERN,
+} from './annotationMarkerSets';
 import { type AnnotationConfig } from './annotationConfig';
 import { collectRegexMatches, type TextMatch } from './markerScanning';
 import { interiorsToRanges } from './rangeUtils';
@@ -10,36 +15,6 @@ type ReplaceMarkerKind = 'start' | 'with' | 'end';
 interface ReplaceMarker extends TextMatch {
   kind: ReplaceMarkerKind;
 }
-
-interface ReplaceMarkerSet {
-  start: RegExp;
-  withMarker: RegExp;
-  end: RegExp;
-}
-
-const REPLACE_MARKER_SETS: ReplaceMarkerSet[] = [
-  {
-    start: /\/\*replace-start\*\//g,
-    withMarker: /\/\*with(?: +i\d+)?\*\//g,
-    end: /\/\*replace-end\*\//g,
-  },
-  {
-    start: /#replace-start#/g,
-    withMarker: /#with(?: +i\d+)?#/g,
-    end: /#replace-end#/g,
-  },
-  {
-    start: /<!--replace-start-->/g,
-    withMarker: /<!--with(?: +i\d+)?-->/g,
-    end: /<!--replace-end-->/g,
-  },
-];
-
-const REPLACE_START_END_MARKER_PATTERN =
-  /\/\*replace-start\*\/|\/\*replace-end\*\/|#replace-start#|#replace-end#|<!--replace-start-->|<!--replace-end-->/g;
-
-const WITH_MARKER_PATTERN =
-  /\/\*with(?: +i\d+)?\*\/|#with(?: +i\d+)?#|<!--with(?: +i\d+)?-->/g;
 
 let boundaryDecoration = vscode.window.createTextEditorDecorationType({});
 let withDecoration = vscode.window.createTextEditorDecorationType({});
@@ -97,7 +72,7 @@ function findReplaceBlockRegions(text: string): ReplaceBlockRegions {
   const originalInteriors: Array<{ start: number; end: number }> = [];
   const replacementInteriors: Array<{ start: number; end: number }> = [];
 
-  for (const markerSet of REPLACE_MARKER_SETS) {
+  for (const markerSet of REPLACE_WITH_MARKER_SETS) {
     const markers = [
       ...collectReplaceMarkers(text, markerSet.start, 'start'),
       ...collectReplaceMarkers(text, markerSet.withMarker, 'with'),


### PR DESCRIPTION
## Overview
- surface annotation pairing errors as inline squiggles and Problems panel entries while editing supported reference files
- port the CLI annotation validator to TypeScript, covering remove, insert, replace (including `with`), and partial blocks across Dart, shell, and HTML comment flavors
- refresh diagnostics on file open and edit, and clear them when a file is closed or errors are fixed
- highlight the full offending marker span rather than a single character at the match offset