### PR TITLE
feat(brick-generator): expose installable brick_generator CLI executable

### DIFF
--- a/tools/brick_generator/bin/brick_generator.dart
+++ b/tools/brick_generator/bin/brick_generator.dart
@@ -1,0 +1,5 @@
+import 'package:brick_generator/main.dart' as cli;
+
+Future<void> main(List<String> args) async {
+  await cli.main(args);
+}

--- a/tools/brick_generator/lib/src/models/replacement.dart
+++ b/tools/brick_generator/lib/src/models/replacement.dart
@@ -29,9 +29,12 @@ class Replacement with ReplacementMappable {
   String apply(String input) => input.replaceAllMapped(from, (match) {
     match as RegExpMatch;
     final toGroupMatches = RegExp(r'\${(\d+)}').allMatches(to);
-    final toGroups = toGroupMatches
-        .map((match) => int.parse(match.group(1)!))
-        .toSet();
+    final seenGroups = <int>{};
+    final toGroups = [
+      for (final groupMatch in toGroupMatches)
+        if (seenGroups.add(int.parse(groupMatch.group(1)!)))
+          int.parse(groupMatch.group(1)!),
+    ];
     final resolvedTo = toGroups.fold(
       to,
       (resolved, group) => resolved.replaceAll(

--- a/tools/brick_generator/pubspec.yaml
+++ b/tools/brick_generator/pubspec.yaml
@@ -3,6 +3,9 @@ description: A generator for bricks.
 publish_to: none
 resolution: workspace
 
+executables:
+  brick_generator:
+
 environment:
   sdk: ">=3.10.0 <4.0.0"
 


### PR DESCRIPTION
## Overview

Exposes `brick_generator` as an installable executable via `dart install`, so consumers (including the VS Code extension) can invoke `brick_generator preview` from PATH instead of `dart run tools/brick_generator/lib/main.dart`.

Also resolves capture-group placeholders in replacement `to` strings in left-to-right order when the same group appears more than once.