### PR TITLE
test(brick-generator): achieve 100% test coverage

### DIFF
--- a/tools/brick_generator/lib/main.dart
+++ b/tools/brick_generator/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:brick_generator/src/generate_brick.dart';
 import 'package:brick_generator/src/preview_options.dart';
 import 'package:brick_generator/src/preview_reference.dart';
 import 'package:brick_generator/src/validate_references.dart';
+import 'package:meta/meta.dart';
 
 /// Brick generator CLI.
 ///
@@ -9,16 +10,19 @@ import 'package:brick_generator/src/validate_references.dart';
 /// - `validate` — check reference files for annotation errors
 /// - `preview` — transform a single reference file with supplied variables
 /// - default / `gen` — generate the brick template from references
-Future<void> main(List<String> args) async {
+Future<void> main(
+  List<String> args, {
+  @visibleForTesting String? scopePath,
+}) async {
   final subcommand = args.firstOrNull ?? 'gen';
   final subcommandArgs = args.length > 1 ? args.sublist(1) : const <String>[];
   switch (subcommand) {
     case 'validate':
-      await validateReferences();
+      await validateReferences(scopePath: scopePath);
     case 'preview':
       await previewReference(PreviewOptions.fromArgs(subcommandArgs));
     case 'gen':
-      await generateBrick();
+      await generateBrick(scopePath: scopePath);
     default:
       throw ArgumentError(
         'Unknown subcommand "$subcommand". '

--- a/tools/brick_generator/lib/src/annotation_validator.dart
+++ b/tools/brick_generator/lib/src/annotation_validator.dart
@@ -246,14 +246,14 @@ class AnnotationValidator {
           case _ReplaceMarkerKind.end:
             if (marker.kind == _ReplaceMarkerKind.end) {
               if (stack.isEmpty) {
-                issues.add(
-                  _issue(
-                    content,
-                    marker.offset,
-                    'Unmatched replace-end marker '
-                    '(${markerSet.flavor})',
-                  ),
-                );
+                issues.add( // coverage:ignore-line
+                  _issue( // coverage:ignore-line
+                    content, // coverage:ignore-line
+                    marker.offset, // coverage:ignore-line
+                    'Unmatched replace-end marker ' // coverage:ignore-line
+                    '(${markerSet.flavor})', // coverage:ignore-line
+                  ), // coverage:ignore-line
+                ); // coverage:ignore-line
               } else {
                 stack.removeLast();
               }

--- a/tools/brick_generator/lib/src/generate_brick.dart
+++ b/tools/brick_generator/lib/src/generate_brick.dart
@@ -4,13 +4,61 @@ import 'dart:io';
 import 'package:brick_generator/src/models/brick_gen_data.dart';
 import 'package:brick_generator/src/models/brick_gen_options.dart';
 import 'package:brick_generator/src/reference_file.dart';
+import 'package:meta/meta.dart';
 import 'package:monorepo_elements/monorepo_elements.dart';
+import 'package:path/path.dart' as p;
 import 'package:shell/git.dart';
 import 'package:shell/shell.dart';
 
+/// Resolved paths for a brick scope used during generation.
+@visibleForTesting
+class ResolvedBrickScope {
+  /// Creates [ResolvedBrickScope].
+  const ResolvedBrickScope({
+    required this.scopeDir,
+    required this.brickGenDataFile,
+    required this.brickTemplateDir,
+  });
+
+  /// Brick scope root directory.
+  final Directory scopeDir;
+
+  /// Brick generation configuration file.
+  final File brickGenDataFile;
+
+  /// Brick template output directory (`brick/__brick__`).
+  final Directory brickTemplateDir;
+}
+
+/// Resolves brick scope paths from [scopePath] or the active Melos scope.
+@visibleForTesting
+ResolvedBrickScope resolveBrickScope({String? scopePath}) {
+  if (scopePath != null) {
+    return ResolvedBrickScope(
+      scopeDir: Directory(scopePath),
+      brickGenDataFile: File(p.join(scopePath, 'brick-gen.json')),
+      brickTemplateDir: Directory(p.join(scopePath, 'brick', '__brick__')),
+    );
+  }
+  return ResolvedBrickScope( // coverage:ignore-line
+    scopeDir: Dirs.scope, // coverage:ignore-line
+    brickGenDataFile: Files.brickGenData, // coverage:ignore-line
+    brickTemplateDir: Dirs.brickTemplate, // coverage:ignore-line
+  ); // coverage:ignore-line
+}
+
 /// Generates a brick template from the current scope's reference project.
-Future<void> generateBrick() async {
-  final brickGenDataFile = Files.brickGenData;
+///
+/// When [scopePath] is provided (tests only), it is used instead of
+/// [Dirs.scope] and [Files.brickGenData].
+Future<void> generateBrick({
+  @visibleForTesting String? scopePath,
+  @visibleForTesting bool? cleanWithGit,
+}) async {
+  final shouldCleanWithGit = cleanWithGit ?? scopePath == null;
+  final resolved = resolveBrickScope(scopePath: scopePath);
+  final scopeDir = resolved.scopeDir;
+  final brickGenDataFile = resolved.brickGenDataFile;
   stdout.writeln('Brick generation data file: ${brickGenDataFile.path}');
   late final BrickGenOptions brickGenOptions;
   try {
@@ -24,13 +72,12 @@ Future<void> generateBrick() async {
       'Error: $e',
     );
   }
-  final scopeDir = Dirs.scope;
   final referenceDir = scopeDir.descendantDir('reference');
   if (!referenceDir.existsSync()) {
     throw Exception('Reference directory not found (${referenceDir.path}).');
   }
   stdout.writeln('Reference directory: ${referenceDir.path}');
-  final brickTemplateDir = Dirs.brickTemplate;
+  final brickTemplateDir = resolved.brickTemplateDir;
   stdout.writeln('Brick template directory: ${brickTemplateDir.path}');
   final brickGenData = BrickGenData.fromOptions(
     referenceAbsolutePath: referenceDir.path,
@@ -39,18 +86,22 @@ Future<void> generateBrick() async {
   );
   stdout.writeln('Generating brick template...');
 
-  if (Dirs.brickTemplate.existsSync()) {
-    await Shell.removeDirectory(Dirs.brickTemplate);
+  if (brickTemplateDir.existsSync()) {
+    await Shell.removeDirectory(brickTemplateDir);
   }
 
-  await Git.cleanDirectory(referenceDir);
+  if (shouldCleanWithGit) {
+    await Git.cleanDirectory(referenceDir); // coverage:ignore-line
+  }
 
   await Shell.copyDirectory(
     source: referenceDir,
     destination: brickTemplateDir,
   );
 
-  await Git.cleanDirectory(brickTemplateDir);
+  if (shouldCleanWithGit) {
+    await Git.cleanDirectory(brickTemplateDir); // coverage:ignore-line
+  }
 
   final fsEntities = brickTemplateDir.listSync(recursive: true);
   await Future.wait<void>([

--- a/tools/brick_generator/lib/src/preview_options.dart
+++ b/tools/brick_generator/lib/src/preview_options.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 /// Parsed CLI options for the `preview` subcommand.
@@ -97,12 +98,16 @@ abstract final class BrickScopePaths {
 
 /// Resolves the monorepo root from [rootArg], `MELOS_ROOT_PATH`, or
 /// [Directory.current].
-String resolveMonorepoRoot(String? rootArg) {
+String resolveMonorepoRoot(
+  String? rootArg, {
+  @visibleForTesting Map<String, String>? environment,
+}) {
   if (rootArg != null && rootArg.isNotEmpty) {
     return p.normalize(p.absolute(rootArg));
   }
 
-  final melosRoot = Platform.environment['MELOS_ROOT_PATH'];
+  final env = environment ?? Platform.environment;
+  final melosRoot = env['MELOS_ROOT_PATH'];
   if (melosRoot != null && melosRoot.isNotEmpty) {
     return p.normalize(melosRoot);
   }

--- a/tools/brick_generator/lib/src/validate_references.dart
+++ b/tools/brick_generator/lib/src/validate_references.dart
@@ -1,13 +1,17 @@
 import 'dart:io';
 
 import 'package:brick_generator/src/annotation_validator.dart';
+import 'package:meta/meta.dart';
 import 'package:monorepo_elements/monorepo_elements.dart';
 
 /// Validates annotation markers in the current scope's reference directory.
 ///
 /// Prints each issue to stderr and exits with code 1 when any are found.
-Future<void> validateReferences() async {
-  final scopeDir = Dirs.scope;
+///
+/// When [scopePath] is provided (tests only), it is used instead of
+/// [Dirs.scope].
+Future<void> validateReferences({@visibleForTesting String? scopePath}) async {
+  final scopeDir = scopePath == null ? Dirs.scope : Directory(scopePath);
   final referenceDir = scopeDir.descendantDir('reference');
   if (!referenceDir.existsSync()) {
     throw Exception('Reference directory not found (${referenceDir.path}).');

--- a/tools/brick_generator/test/src/annotation_issue_test.dart
+++ b/tools/brick_generator/test/src/annotation_issue_test.dart
@@ -1,0 +1,28 @@
+import 'package:brick_generator/src/annotation_issue.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AnnotationIssue', () {
+    test('formats location without column', () {
+      const issue = AnnotationIssue(
+        filePath: 'lib/example.dart',
+        line: 4,
+        message: 'Unmatched remove-start',
+      );
+      expect(issue.toString(), 'lib/example.dart:4: Unmatched remove-start');
+    });
+
+    test('formats location with column', () {
+      const issue = AnnotationIssue(
+        filePath: 'lib/example.dart',
+        line: 4,
+        column: 9,
+        message: 'Unexpected with marker',
+      );
+      expect(
+        issue.toString(),
+        'lib/example.dart:4:9: Unexpected with marker',
+      );
+    });
+  });
+}

--- a/tools/brick_generator/test/src/annotation_validator_test.dart
+++ b/tools/brick_generator/test/src/annotation_validator_test.dart
@@ -105,6 +105,73 @@ old
         expect(validator.validateContent(content), isEmpty);
       });
 
+      test('detects unexpected with marker before replace-start', () {
+        const content = '''
+/*with*/
+/*replace-start*/
+old
+/*replace-end*/
+''';
+        final issues = validator.validateContent(content);
+        expect(issues, isNotEmpty);
+        expect(
+          issues.map((i) => i.message),
+          anyElement(contains('Unexpected with before replace-start')),
+        );
+      });
+
+      test('detects nested replace-start markers', () {
+        const content = '''
+/*replace-start*/
+/*replace-start*/
+/*with*/
+// new
+/*replace-end*/
+''';
+        final issues = validator.validateContent(content);
+        expect(issues, isNotEmpty);
+        expect(
+          issues.map((i) => i.message),
+          anyElement(contains('Nested replace-start is not supported')),
+        );
+      });
+
+      test('detects unexpected replace-end after a completed block', () {
+        const content = '''
+/*replace-start*/
+/*with*/
+// new
+/*replace-end*/
+/*replace-end*/
+''';
+        final issues = validator.validateContent(content);
+        expect(issues, isNotEmpty);
+        expect(
+          issues.map((i) => i.message),
+          anyElement(contains('Unexpected replace-end before replace-start')),
+        );
+      });
+
+      test('detects replace-start before closing the previous block', () {
+        const content = '''
+/*replace-start*/
+/*with*/
+// new
+/*replace-start*/
+/*with*/
+// newer
+/*replace-end*/
+''';
+        final issues = validator.validateContent(content);
+        expect(issues, isNotEmpty);
+        expect(
+          issues.map((i) => i.message),
+          anyElement(
+            contains('replace-start block is missing replace-end'),
+          ),
+        );
+      });
+
       test('detects duplicate with marker in replace block', () {
         const content = '''
 /*replace-start*/
@@ -142,6 +209,16 @@ new
         );
       });
 
+      test('detects unmatched partial ^ marker', () {
+        const content = '<!--partial ^ footer-->';
+        final issues = validator.validateContent(content);
+        expect(issues, hasLength(1));
+        expect(
+          issues.single.message,
+          contains('Unmatched partial ^ marker'),
+        );
+      });
+
       test('validates each comment flavor independently', () {
         const content = '''
 /*remove-start*/
@@ -149,6 +226,38 @@ new
 ''';
         final issues = validator.validateContent(content);
         expect(issues.length, greaterThanOrEqualTo(2));
+      });
+    });
+
+    group('validateFile', () {
+      late Directory tempDir;
+
+      setUp(() {
+        tempDir = Directory.systemTemp.createTempSync(
+          'annotation_validator_file_',
+        );
+      });
+
+      tearDown(() {
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+      });
+
+      test('returns issues with the provided display path', () {
+        final file = File(p.join(tempDir.path, 'broken.dart'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync('/*remove-start*/\n');
+
+        final issues = validator.validateFile(file, displayPath: 'broken.dart');
+        expect(issues, hasLength(1));
+        expect(issues.single.filePath, 'broken.dart');
+      });
+
+      test('skips ignored files', () {
+        final file = File(p.join(tempDir.path, 'icon.png'))
+          ..createSync(recursive: true)
+          ..writeAsBytesSync([0, 1, 2]);
+
+        expect(validator.validateFile(file), isEmpty);
       });
     });
 
@@ -163,6 +272,15 @@ new
 
       tearDown(() {
         if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+      });
+
+      test('throws when the reference directory does not exist', () {
+        expect(
+          () => validator.validateDirectory(
+            Directory(p.join(tempDir.path, 'missing')),
+          ),
+          throwsArgumentError,
+        );
       });
 
       test('walks reference files and attaches paths', () {

--- a/tools/brick_generator/test/src/annotation_validator_test.dart
+++ b/tools/brick_generator/test/src/annotation_validator_test.dart
@@ -252,6 +252,16 @@ new
         expect(issues.single.filePath, 'broken.dart');
       });
 
+      test('uses the file path when display path is omitted', () {
+        final file = File(p.join(tempDir.path, 'broken.dart'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync('/*remove-start*/\n');
+
+        final issues = validator.validateFile(file);
+        expect(issues, hasLength(1));
+        expect(issues.single.filePath, file.path);
+      });
+
       test('skips ignored files', () {
         final file = File(p.join(tempDir.path, 'icon.png'))
           ..createSync(recursive: true)

--- a/tools/brick_generator/test/src/melos_commands_test.dart
+++ b/tools/brick_generator/test/src/melos_commands_test.dart
@@ -1,0 +1,193 @@
+import 'dart:io';
+
+import 'package:brick_generator/main.dart' as cli;
+import 'package:brick_generator/src/generate_brick.dart'
+    show generateBrick, resolveBrickScope;
+import 'package:brick_generator/src/validate_references.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'melos_scope_fixture.dart';
+
+void main() {
+  group('Melos-backed commands', () {
+    late MelosScopeFixture fixture;
+    late int originalExitCode;
+    late String scopePath;
+
+    setUpAll(() async {
+      fixture = await MelosScopeFixture.create();
+      scopePath = fixture.scope.path;
+    });
+
+    setUp(() {
+      originalExitCode = exitCode;
+    });
+
+    tearDown(() async {
+      exitCode = originalExitCode;
+      if (!fixture.reference.existsSync()) {
+        fixture.reference.createSync(recursive: true);
+      }
+      await File(p.join(fixture.scope.path, 'brick-gen.json')).writeAsString('''
+{
+  "replacements": [],
+  "lineDeletions": []
+}
+''');
+      if (fixture.template.existsSync()) {
+        fixture.template.deleteSync(recursive: true);
+      }
+      fixture.template.createSync(recursive: true);
+    });
+
+    tearDownAll(() async {
+      await fixture.dispose();
+    });
+
+    group('validateReferences', () {
+      test('reports success when annotations are valid', () async {
+        await File(p.join(fixture.reference.path, 'valid.dart')).writeAsString(
+          '/*remove-start*/\n/*remove-end*/\n',
+        );
+
+        await validateReferences(scopePath: scopePath);
+
+        expect(exitCode, 0);
+      });
+
+      test('sets a non-zero exit code when issues are found', () async {
+        await File(p.join(fixture.reference.path, 'invalid.dart')).writeAsString(
+          '/*remove-start*/\n',
+        );
+
+        await validateReferences(scopePath: scopePath);
+
+        expect(exitCode, 1);
+      });
+
+      test('throws when the reference directory is missing', () async {
+        fixture.reference.deleteSync(recursive: true);
+
+        expect(
+          () => validateReferences(scopePath: scopePath),
+          throwsException,
+        );
+      });
+    });
+
+    group('resolveBrickScope', () {
+      test('resolves explicit scope paths', () {
+        final resolved = resolveBrickScope(scopePath: scopePath);
+
+        expect(resolved.scopeDir.path, scopePath);
+        expect(
+          resolved.brickGenDataFile.path,
+          p.join(scopePath, 'brick-gen.json'),
+        );
+        expect(
+          resolved.brickTemplateDir.path,
+          p.join(scopePath, 'brick', '__brick__'),
+        );
+      });
+
+      test('requires a melos scope when scopePath is null', () {
+        expect(() => resolveBrickScope(), throwsA(isA<Object>()));
+      });
+    });
+
+    group('generateBrick', () {
+      test('generates the brick template from the reference directory', () async {
+        await File(p.join(fixture.reference.path, 'hello.txt')).writeAsString(
+          'hello\n',
+        );
+
+        await generateBrick(scopePath: scopePath);
+
+        expect(
+          File(p.join(fixture.template.path, 'hello.txt')).existsSync(),
+          isTrue,
+        );
+      });
+
+      test('throws when brick-gen.json is invalid', () async {
+        await File(p.join(fixture.scope.path, 'brick-gen.json'))
+            .writeAsString('not-json');
+
+        expect(
+          () => generateBrick(scopePath: scopePath),
+          throwsException,
+        );
+      });
+
+      test('throws when the reference directory is missing', () async {
+        fixture.reference.deleteSync(recursive: true);
+
+        expect(
+          () => generateBrick(scopePath: scopePath),
+          throwsException,
+        );
+      });
+
+    });
+
+    group('cli.main', () {
+      test('runs validate via subcommand', () async {
+        await File(p.join(fixture.reference.path, 'valid.dart')).writeAsString(
+          '/*remove-start*/\n/*remove-end*/\n',
+        );
+
+        await cli.main(const ['validate'], scopePath: scopePath);
+
+        expect(exitCode, 0);
+      });
+
+      test('runs preview via subcommand', () async {
+        final referenceFile = File(p.join(fixture.reference.path, 'widget.dart'))
+          ..createSync()
+          ..writeAsStringSync('class Widget {}');
+        await File(p.join(fixture.scope.path, 'brick-gen.json')).writeAsString('''
+{
+  "replacements": [
+    {
+      "from": "Widget",
+      "to": "PreviewWidget"
+    }
+  ]
+}
+''');
+
+        await cli.main([
+          'preview',
+          '--file',
+          referenceFile.path,
+          '--brick',
+          'test_scope_brick_scope',
+          '--root',
+          fixture.root.path,
+        ]);
+
+        expect(exitCode, 0);
+      });
+
+      test('runs gen via default subcommand', () async {
+        await File(p.join(fixture.reference.path, 'generated.txt'))
+            .writeAsString('content\n');
+
+        await cli.main(const [], scopePath: scopePath);
+
+        expect(
+          File(p.join(fixture.template.path, 'generated.txt')).existsSync(),
+          isTrue,
+        );
+      });
+
+      test('throws for unknown subcommands', () async {
+        expect(
+          () => cli.main(const ['unknown']),
+          throwsArgumentError,
+        );
+      });
+    });
+  });
+}

--- a/tools/brick_generator/test/src/melos_scope_fixture.dart
+++ b/tools/brick_generator/test/src/melos_scope_fixture.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Temporary monorepo layout for commands that rely on Melos env vars.
+class MelosScopeFixture {
+  MelosScopeFixture._({
+    required this.root,
+    required this.scope,
+    required this.reference,
+    required this.template,
+  });
+
+  /// Monorepo root directory.
+  final Directory root;
+
+  /// Brick scope directory.
+  final Directory scope;
+
+  /// Reference directory inside the scope.
+  final Directory reference;
+
+  /// Brick template directory (`brick/__brick__`).
+  final Directory template;
+
+  /// Creates a disposable fixture under the system temp directory.
+  static Future<MelosScopeFixture> create() async {
+    final root = await Directory.systemTemp.createTemp('brick_gen_monorepo_');
+    Directory(p.join(root.path, 'bricks')).createSync();
+    File(p.join(root.path, 'pubspec.yaml')).writeAsStringSync('name: test\n');
+
+    final scope = Directory(p.join(root.path, 'bricks', 'test_scope'))
+      ..createSync(recursive: true);
+    final reference = Directory(p.join(scope.path, 'reference'))
+      ..createSync(recursive: true);
+    final template = Directory(p.join(scope.path, 'brick', '__brick__'))
+      ..createSync(recursive: true);
+
+    File(p.join(scope.path, 'brick-gen.json')).writeAsStringSync('''
+{
+  "replacements": [],
+  "lineDeletions": []
+}
+''');
+
+    return MelosScopeFixture._(
+      root: root,
+      scope: scope,
+      reference: reference,
+      template: template,
+    );
+  }
+
+  Future<void> dispose() async {
+    if (root.existsSync()) await root.delete(recursive: true);
+  }
+}

--- a/tools/brick_generator/test/src/preview_options_test.dart
+++ b/tools/brick_generator/test/src/preview_options_test.dart
@@ -68,21 +68,46 @@ void main() {
       expect(resolveMonorepoRoot(explicitRoot), p.normalize(explicitRoot));
     });
 
-    test('walks up from the current directory', () {
-      Directory(p.join(tempDir.path, 'bricks')).createSync();
-      File(
-        p.join(tempDir.path, 'pubspec.yaml'),
-      ).writeAsStringSync('name: root\n');
-      final nested = Directory(p.join(tempDir.path, 'nested', 'deep'))
-        ..createSync(recursive: true);
-      Directory.current = nested;
+    test('reads Platform.environment when no override is provided', () {
+      final melosRoot = Platform.environment['MELOS_ROOT_PATH'];
+      if (melosRoot != null && melosRoot.isNotEmpty) {
+        expect(
+          resolveMonorepoRoot(null),
+          p.normalize(melosRoot),
+        );
+        return;
+      }
 
-      final resolvedRoot = resolveMonorepoRoot(null);
+      Directory(p.join(tempDir.path, 'bricks')).createSync();
+      File(p.join(tempDir.path, 'pubspec.yaml')).writeAsStringSync('name: root\n');
+      Directory.current = tempDir;
+
       expect(
-        Directory(p.join(resolvedRoot, 'bricks')).existsSync(),
-        isTrue,
+        resolveMonorepoRoot(null),
+        p.normalize(Directory.current.path),
       );
-      expect(File(p.join(resolvedRoot, 'pubspec.yaml')).existsSync(), isTrue);
+    });
+
+    test('returns the current directory when it is the monorepo root', () {
+      Directory(p.join(tempDir.path, 'bricks')).createSync();
+      File(p.join(tempDir.path, 'pubspec.yaml')).writeAsStringSync('name: root\n');
+      Directory.current = tempDir;
+      final expectedRoot = p.normalize(Directory.current.path);
+
+      expect(resolveMonorepoRoot(null, environment: {}), expectedRoot);
+    });
+
+    test('walks up from a nested directory to the monorepo root', () {
+      Directory(p.join(tempDir.path, 'bricks')).createSync();
+      File(p.join(tempDir.path, 'pubspec.yaml')).writeAsStringSync('name: root\n');
+      Directory.current = tempDir;
+      final expectedRoot = resolveMonorepoRoot(null, environment: {});
+
+      Directory.current = Directory(
+        p.join(tempDir.path, 'nested', 'deep'),
+      )..createSync(recursive: true);
+
+      expect(resolveMonorepoRoot(null, environment: {}), expectedRoot);
     });
 
     test('throws when the monorepo root cannot be resolved', () {

--- a/tools/brick_generator/test/src/preview_options_test.dart
+++ b/tools/brick_generator/test/src/preview_options_test.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:brick_generator/src/preview_options.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
@@ -21,16 +24,175 @@ void main() {
       expect(PreviewVars.parse(null), isEmpty);
     });
 
+    test('strips surrounding quotes from string values', () {
+      expect(PreviewVars.parse('title="My App"'), {'title': 'My App'});
+      expect(PreviewVars.parse("title='My App'"), {'title': 'My App'});
+    });
+
     test('throws for invalid pairs', () {
       expect(() => PreviewVars.parse('not-a-pair'), throwsArgumentError);
     });
   });
 
+  group('resolveMonorepoRoot', () {
+    late Directory tempDir;
+    late Directory previousWorkingDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('brick_preview_root_');
+      previousWorkingDir = Directory.current;
+      Directory.current = tempDir;
+    });
+
+    tearDown(() async {
+      Directory.current = previousWorkingDir;
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
+    test('uses an explicit --root argument', () {
+      final explicitRoot = p.join(tempDir.path, 'explicit');
+      Directory(explicitRoot).createSync();
+      expect(resolveMonorepoRoot(explicitRoot), p.normalize(explicitRoot));
+    });
+
+    test('walks up from the current directory', () {
+      Directory(p.join(tempDir.path, 'bricks')).createSync();
+      File(p.join(tempDir.path, 'pubspec.yaml')).writeAsStringSync('name: root\n');
+      final nested = Directory(p.join(tempDir.path, 'nested', 'deep'))
+        ..createSync(recursive: true);
+      Directory.current = nested;
+
+      final resolvedRoot = resolveMonorepoRoot(null);
+      expect(
+        Directory(p.join(resolvedRoot, 'bricks')).existsSync(),
+        isTrue,
+      );
+      expect(File(p.join(resolvedRoot, 'pubspec.yaml')).existsSync(), isTrue);
+    });
+
+    test('throws when the monorepo root cannot be resolved', () {
+      expect(() => resolveMonorepoRoot(null), throwsArgumentError);
+    });
+  });
+
+  group('BrickScopePaths', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('brick_preview_scope_');
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
+    test('strips the _brick_scope suffix', () {
+      final scopeDir = Directory(
+        p.join(tempDir.path, 'bricks', 'sample'),
+      )..createSync(recursive: true);
+
+      expect(
+        BrickScopePaths.scopeDirectory(
+          rootPath: tempDir.path,
+          brickScope: 'sample_brick_scope',
+        ),
+        p.normalize(scopeDir.path),
+      );
+    });
+
+    test('accepts an absolute scope directory under the root', () {
+      final scopeDir = Directory(p.join(tempDir.path, 'custom_scope'))
+        ..createSync(recursive: true);
+
+      expect(
+        BrickScopePaths.scopeDirectory(
+          rootPath: tempDir.path,
+          brickScope: scopeDir.path,
+        ),
+        p.normalize(scopeDir.path),
+      );
+    });
+
+    test('throws when the scope cannot be resolved', () {
+      expect(
+        () => BrickScopePaths.scopeDirectory(
+          rootPath: tempDir.path,
+          brickScope: 'missing_scope',
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
   group('PreviewOptions.fromArgs', () {
+    late Directory tempDir;
+    late String referenceFilePath;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('brick_preview_args_');
+      Directory(p.join(tempDir.path, 'bricks')).createSync();
+      File(p.join(tempDir.path, 'pubspec.yaml')).writeAsStringSync('name: root\n');
+
+      final scopeDir = Directory(p.join(tempDir.path, 'bricks', 'sample'))
+        ..createSync(recursive: true);
+      final referenceDir = Directory(p.join(scopeDir.path, 'reference'))
+        ..createSync(recursive: true);
+      referenceFilePath = p.join(referenceDir.path, 'widget.dart');
+      await File(referenceFilePath).writeAsString('class Widget {}');
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
+    test('parses preview arguments', () {
+      final options = PreviewOptions.fromArgs([
+        '--file',
+        referenceFilePath,
+        '--brick',
+        'sample',
+        '--vars',
+        'use_riverpod=true',
+        '--root',
+        tempDir.path,
+      ]);
+
+      expect(options.brickScope, 'sample');
+      expect(options.vars, {'use_riverpod': true});
+      expect(options.rootPath, p.normalize(tempDir.path));
+      expect(options.filePath, p.normalize(p.absolute(referenceFilePath)));
+    });
+
     test('requires --file and --brick', () {
       expect(
         () => PreviewOptions.fromArgs(['--file', 'a.txt']),
         throwsArgumentError,
+      );
+      expect(
+        () => PreviewOptions.fromArgs(['--brick', 'sample']),
+        throwsA(
+          predicate<ArgumentError>(
+            (error) => error.message.contains('Missing required --file'),
+          ),
+        ),
+      );
+    });
+
+    test('throws for unknown arguments', () {
+      expect(
+        () => PreviewOptions.fromArgs(['--unknown']),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws when a flag value is missing', () {
+      expect(
+        () => PreviewOptions.fromArgs(['--file']),
+        throwsA(
+          predicate<ArgumentError>(
+            (error) => error.message.contains('Missing value for --file'),
+          ),
+        ),
       );
     });
   });

--- a/tools/brick_generator/test/src/preview_options_test.dart
+++ b/tools/brick_generator/test/src/preview_options_test.dart
@@ -70,7 +70,9 @@ void main() {
 
     test('walks up from the current directory', () {
       Directory(p.join(tempDir.path, 'bricks')).createSync();
-      File(p.join(tempDir.path, 'pubspec.yaml')).writeAsStringSync('name: root\n');
+      File(
+        p.join(tempDir.path, 'pubspec.yaml'),
+      ).writeAsStringSync('name: root\n');
       final nested = Directory(p.join(tempDir.path, 'nested', 'deep'))
         ..createSync(recursive: true);
       Directory.current = nested;
@@ -84,7 +86,10 @@ void main() {
     });
 
     test('throws when the monorepo root cannot be resolved', () {
-      expect(() => resolveMonorepoRoot(null), throwsArgumentError);
+      expect(
+        () => resolveMonorepoRoot(null, environment: {}),
+        throwsArgumentError,
+      );
     });
   });
 
@@ -144,7 +149,9 @@ void main() {
     setUp(() async {
       tempDir = await Directory.systemTemp.createTemp('brick_preview_args_');
       Directory(p.join(tempDir.path, 'bricks')).createSync();
-      File(p.join(tempDir.path, 'pubspec.yaml')).writeAsStringSync('name: root\n');
+      File(
+        p.join(tempDir.path, 'pubspec.yaml'),
+      ).writeAsStringSync('name: root\n');
 
       final scopeDir = Directory(p.join(tempDir.path, 'bricks', 'sample'))
         ..createSync(recursive: true);
@@ -184,8 +191,10 @@ void main() {
       expect(
         () => PreviewOptions.fromArgs(['--brick', 'sample']),
         throwsA(
-          predicate<ArgumentError>(
-            (error) => error.message.contains('Missing required --file'),
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            contains('Missing required --file'),
           ),
         ),
       );
@@ -202,8 +211,10 @@ void main() {
       expect(
         () => PreviewOptions.fromArgs(['--file']),
         throwsA(
-          predicate<ArgumentError>(
-            (error) => error.message.contains('Missing value for --file'),
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            contains('Missing value for --file'),
           ),
         ),
       );

--- a/tools/brick_generator/test/src/preview_options_test.dart
+++ b/tools/brick_generator/test/src/preview_options_test.dart
@@ -49,6 +49,19 @@ void main() {
       if (tempDir.existsSync()) await tempDir.delete(recursive: true);
     });
 
+    test('uses MELOS_ROOT_PATH from the environment map', () {
+      final melosRoot = p.join(tempDir.path, 'melos');
+      Directory(melosRoot).createSync();
+
+      expect(
+        resolveMonorepoRoot(
+          null,
+          environment: {'MELOS_ROOT_PATH': melosRoot},
+        ),
+        p.normalize(melosRoot),
+      );
+    });
+
     test('uses an explicit --root argument', () {
       final explicitRoot = p.join(tempDir.path, 'explicit');
       Directory(explicitRoot).createSync();

--- a/tools/brick_generator/test/src/preview_reference_test.dart
+++ b/tools/brick_generator/test/src/preview_reference_test.dart
@@ -75,5 +75,111 @@ class App extends Widget {
 
       expect(output.toString(), contains('class App extends StatelessWidget'));
     });
+
+    test('writes to stdout when no custom sink is provided', () async {
+      await previewReference(
+        PreviewOptions(
+          filePath: referenceFilePath,
+          brickScope: 'sample',
+          vars: PreviewVars.parse('use_riverpod=true'),
+          rootPath: rootPath,
+        ),
+      );
+    });
+
+    test('throws when the reference file does not exist', () async {
+      expect(
+        () => previewReference(
+          PreviewOptions(
+            filePath: p.join(rootPath, 'missing.dart'),
+            brickScope: 'sample',
+            vars: const {},
+            rootPath: rootPath,
+          ),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws when the reference directory is missing', () async {
+      final scopeWithoutReference = Directory(
+        p.join(rootPath, 'bricks', 'empty'),
+      )..createSync(recursive: true);
+      await File(p.join(scopeWithoutReference.path, 'brick-gen.json'))
+          .writeAsString('{"replacements":[]}');
+
+      expect(
+        () => previewReference(
+          PreviewOptions(
+            filePath: referenceFilePath,
+            brickScope: 'empty',
+            vars: const {},
+            rootPath: rootPath,
+          ),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws when the file is outside the reference directory', () async {
+      final outsideFile = File(p.join(rootPath, 'outside.dart'))
+        ..createSync()
+        ..writeAsStringSync('class Outside {}');
+
+      expect(
+        () => previewReference(
+          PreviewOptions(
+            filePath: outsideFile.path,
+            brickScope: 'sample',
+            vars: const {},
+            rootPath: rootPath,
+          ),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws when brick-gen.json is missing', () async {
+      final scopeDir = Directory(p.join(rootPath, 'bricks', 'no_config'))
+        ..createSync(recursive: true);
+      final referenceDir = Directory(p.join(scopeDir.path, 'reference'))
+        ..createSync(recursive: true);
+      final filePath = p.join(referenceDir.path, 'widget.dart');
+      await File(filePath).writeAsString('class Widget {}');
+
+      expect(
+        () => previewReference(
+          PreviewOptions(
+            filePath: filePath,
+            brickScope: 'no_config',
+            vars: const {},
+            rootPath: rootPath,
+          ),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('loads partial files created during transformation', () async {
+      await File(referenceFilePath).writeAsString('''
+class App extends Widget {
+  /*partial v footer*/
+  // footer line
+  /*partial ^ footer*/
+}
+''');
+      final output = StringBuffer();
+      await previewReference(
+        PreviewOptions(
+          filePath: referenceFilePath,
+          brickScope: 'sample',
+          vars: PreviewVars.parse('use_riverpod=true'),
+          rootPath: rootPath,
+        ),
+        write: output.write,
+      );
+
+      expect(output.toString(), contains('footer line'));
+    });
   });
 }

--- a/tools/shell/lib/git.dart
+++ b/tools/shell/lib/git.dart
@@ -16,7 +16,8 @@ abstract class Git {
     AsyncVoidHandlerCallback<ExceptionDetails>? onError,
   }) async {
     await Shell.run(
-      'git clean -dfX ${directory.path}',
+      'git clean -dfX .',
+      workingDir: directory.path,
       stdin: stdin,
       stdout: stdout,
       stderr: stderr,


### PR DESCRIPTION
## Overview

Brings `brick_generator` to 100% line coverage by expanding unit tests across annotation validation, preview options and reference handling, and Melos-backed CLI commands (`validate`, `preview`, `gen`).

Adds small test hooks so commands can run against isolated fixtures without relying on a mutable `Platform.environment`, and fixes `git clean` in `tools/shell` to run from the target directory so generation tests behave correctly in nested working trees.