### PR TITLE
feat(brick-generator): preview template output without variable resolution

### DIFF
--- a/tools/brick_generator/lib/main.dart
+++ b/tools/brick_generator/lib/main.dart
@@ -8,7 +8,8 @@ import 'package:meta/meta.dart';
 ///
 /// Subcommands:
 /// - `validate` — check reference files for annotation errors
-/// - `preview` — transform a single reference file with supplied variables
+/// - `preview` — transform a single reference file; use `--template-only` to
+///   skip Mustache variable resolution
 /// - default / `gen` — generate the brick template from references
 Future<void> main(
   List<String> args, {

--- a/tools/brick_generator/lib/src/preview_options.dart
+++ b/tools/brick_generator/lib/src/preview_options.dart
@@ -11,6 +11,7 @@ class PreviewOptions {
     required this.brickScope,
     required this.vars,
     required this.rootPath,
+    this.templateOnly = false,
   });
 
   /// Parses [args] after the `preview` subcommand name.
@@ -19,10 +20,13 @@ class PreviewOptions {
     String? brickScope;
     String? varsRaw;
     String? rootPath;
+    var templateOnly = false;
 
     for (var index = 0; index < args.length; index++) {
       final arg = args[index];
       switch (arg) {
+        case '--template-only':
+          templateOnly = true;
         case '--file':
           filePath = _readValue(args, index, arg);
           index++;
@@ -52,6 +56,7 @@ class PreviewOptions {
       brickScope: brickScope,
       vars: PreviewVars.parse(varsRaw),
       rootPath: resolveMonorepoRoot(rootPath),
+      templateOnly: templateOnly,
     );
   }
 
@@ -67,6 +72,10 @@ class PreviewOptions {
 
   /// Absolute path to the monorepo root.
   final String rootPath;
+
+  /// When true, applies annotation and [brick-gen.json] transforms only and
+  /// leaves Mustache tags unresolved.
+  final bool templateOnly;
 }
 
 /// Utilities for resolving monorepo and brick-scope paths.

--- a/tools/brick_generator/lib/src/preview_reference.dart
+++ b/tools/brick_generator/lib/src/preview_reference.dart
@@ -78,6 +78,11 @@ Future<void> previewReference(
       brickGenData: brickGenData,
     );
 
+    if (options.templateOnly) {
+      emit(annotatedContent);
+      return;
+    }
+
     final partials = _loadPartials(tempTargetDir);
     final rendered = annotatedContent.render(options.vars, partials);
     emit(rendered);

--- a/tools/brick_generator/test/src/preview_options_test.dart
+++ b/tools/brick_generator/test/src/preview_options_test.dart
@@ -206,6 +206,22 @@ void main() {
       expect(options.vars, {'use_riverpod': true});
       expect(options.rootPath, p.normalize(tempDir.path));
       expect(options.filePath, p.normalize(p.absolute(referenceFilePath)));
+      expect(options.templateOnly, isFalse);
+    });
+
+    test('parses --template-only', () {
+      final options = PreviewOptions.fromArgs([
+        '--template-only',
+        '--file',
+        referenceFilePath,
+        '--brick',
+        'sample',
+        '--root',
+        tempDir.path,
+      ]);
+
+      expect(options.templateOnly, isTrue);
+      expect(options.vars, isEmpty);
     });
 
     test('requires --file and --brick', () {

--- a/tools/brick_generator/test/src/preview_reference_test.dart
+++ b/tools/brick_generator/test/src/preview_reference_test.dart
@@ -61,6 +61,26 @@ class App extends Widget {
       expect(result, isNot(contains('scaffold')));
     });
 
+    test('keeps mustache tags when templateOnly is true', () async {
+      final output = StringBuffer();
+      await previewReference(
+        PreviewOptions(
+          filePath: referenceFilePath,
+          brickScope: 'sample',
+          vars: PreviewVars.parse('use_riverpod=true'),
+          rootPath: rootPath,
+          templateOnly: true,
+        ),
+        write: output.write,
+      );
+
+      final result = output.toString();
+      expect(result, contains('{{#use_riverpod}}ConsumerWidget{{/use_riverpod}}'));
+      expect(result, contains('{{^use_riverpod}}StatelessWidget{{/use_riverpod}}'));
+      expect(result, isNot(contains('class App extends ConsumerWidget')));
+      expect(result, isNot(contains('remove-start')));
+    });
+
     test('selects the stateless branch when use_riverpod is false', () async {
       final output = StringBuffer();
       await previewReference(


### PR DESCRIPTION
## Summary

- Add `--template-only` to the `preview` subcommand so annotation and `brick-gen.json` transforms run without Mason variable resolution.
- Mustache tags (`{{…}}`, conditionals, partials) remain in stdout for template inspection.
- Add unit tests for flag parsing and template-only output.