### PR TITLE
feat(vscode-ext): preview template output without variables

### DIFF
--- a/tools/vscode_extension/README.md
+++ b/tools/vscode_extension/README.md
@@ -26,7 +26,7 @@ The extension:
 
 ## Preview template output
 
-Run **Brick Generator: Preview template output** (or the matching CodeLens) to see the brick template for the current file without resolving Mustache variables. The extension still applies annotation transforms and `brick-gen.json` replacements, so `{{…}}` tags and conditional sections remain visible for inspection.
+Run **Brick Generator: Preview template output** (or the matching CodeLens) to see the brick template for the current file without resolving Mustache variables. The preview still applies annotation transforms and `brick-gen.json` replacements, so `{{…}}` tags and conditional sections remain visible for inspection.
 
 ### CLI prerequisite
 

--- a/tools/vscode_extension/README.md
+++ b/tools/vscode_extension/README.md
@@ -11,7 +11,7 @@ The extension now provides annotation-aware highlighting for all currently suppo
 - Code folding for: `remove-start/end`, `replace-start/end`, and matching `partial v/^` blocks (all three comment flavors)
 - Coverage across reference file types used in this monorepo, including `.dart`, `.sh`, `.yaml`, `.yml`, `.html`, `.xml`, `.md`, and ignore-style files such as `.gitignore`
 - Theme-friendly TextMate scopes with extension-provided defaults for both dark and light themes
-- Inline preview via **Brick Generator: Preview generated output** or **Preview template output** (Command Palette or CodeLens on the first annotation)
+- Inline preview via **Brick Generator: Preview generated output** or **Brick Generator: Preview template output** (Command Palette or CodeLens on the first annotation)
 
 ## Preview generated output
 

--- a/tools/vscode_extension/README.md
+++ b/tools/vscode_extension/README.md
@@ -11,7 +11,7 @@ The extension now provides annotation-aware highlighting for all currently suppo
 - Code folding for: `remove-start/end`, `replace-start/end`, and matching `partial v/^` blocks (all three comment flavors)
 - Coverage across reference file types used in this monorepo, including `.dart`, `.sh`, `.yaml`, `.yml`, `.html`, `.xml`, `.md`, and ignore-style files such as `.gitignore`
 - Theme-friendly TextMate scopes with extension-provided defaults for both dark and light themes
-- Inline preview of generated output via **Brick Generator: Preview generated output** (Command Palette or CodeLens on the first annotation)
+- Inline preview via **Brick Generator: Preview generated output** or **Preview template output** (Command Palette or CodeLens on the first annotation)
 
 ## Preview generated output
 
@@ -22,7 +22,11 @@ The extension:
 1. Detects the brick scope from the nearest `brick-gen.json`
 2. Applies `brick-gen.json` content replacements, then prompts only for Mustache variables referenced in that transformed file (using `brick/brick.yaml` definitions when available)
 3. Remembers last-used values per brick scope as quick-pick defaults
-4. Runs the installed `brick_generator preview` CLI and opens a diff editor with the transformed file
+4. Runs the installed `brick_generator preview` CLI and opens a diff editor with the fully resolved file
+
+## Preview template output
+
+Run **Brick Generator: Preview template output** (or the matching CodeLens) to see the brick template for the current file without resolving Mustache variables. The extension still applies annotation transforms and `brick-gen.json` replacements, so `{{…}}` tags and conditional sections remain visible for inspection.
 
 ### CLI prerequisite
 

--- a/tools/vscode_extension/package.json
+++ b/tools/vscode_extension/package.json
@@ -27,6 +27,11 @@
         "command": "brickGenerator.preview",
         "title": "Preview generated output",
         "category": "Brick Generator"
+      },
+      {
+        "command": "brickGenerator.previewTemplate",
+        "title": "Preview template output",
+        "category": "Brick Generator"
       }
     ],
     "configurationDefaults": {

--- a/tools/vscode_extension/src/previewCodeLens.ts
+++ b/tools/vscode_extension/src/previewCodeLens.ts
@@ -2,7 +2,10 @@ import * as vscode from 'vscode';
 
 import { ANY_ANNOTATION_MARKER_PATTERN } from './annotationMarkerSets';
 import { findBrickScopeForFile } from './brickScope';
-import { PREVIEW_COMMAND_ID } from './previewCommand';
+import {
+  PREVIEW_COMMAND_ID,
+  PREVIEW_TEMPLATE_COMMAND_ID,
+} from './previewCommand';
 import { collectRegexMatches } from './markerScanning';
 import { isSupportedBrickFile } from './supportedFiles';
 
@@ -31,6 +34,11 @@ class PreviewCodeLensProvider implements vscode.CodeLensProvider {
       new vscode.CodeLens(range, {
         title: 'Preview generated output',
         command: PREVIEW_COMMAND_ID,
+        arguments: [document.uri],
+      }),
+      new vscode.CodeLens(range, {
+        title: 'Preview template output',
+        command: PREVIEW_TEMPLATE_COMMAND_ID,
         arguments: [document.uri],
       }),
     ];

--- a/tools/vscode_extension/src/previewCommand.ts
+++ b/tools/vscode_extension/src/previewCommand.ts
@@ -15,21 +15,29 @@ import { isSupportedBrickFile } from './supportedFiles';
 import { collectPreviewVariableValues } from './variableQuickPick';
 
 export const PREVIEW_COMMAND_ID = 'brickGenerator.preview';
+export const PREVIEW_TEMPLATE_COMMAND_ID = 'brickGenerator.previewTemplate';
 
 export function registerPreviewCommand(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       PREVIEW_COMMAND_ID,
       async (uri?: vscode.Uri) => {
-        await previewGeneratedOutput(context, uri);
+        await previewOutput(context, uri, { templateOnly: false });
+      },
+    ),
+    vscode.commands.registerCommand(
+      PREVIEW_TEMPLATE_COMMAND_ID,
+      async (uri?: vscode.Uri) => {
+        await previewOutput(context, uri, { templateOnly: true });
       },
     ),
   );
 }
 
-async function previewGeneratedOutput(
+async function previewOutput(
   context: vscode.ExtensionContext,
-  uri?: vscode.Uri,
+  uri: vscode.Uri | undefined,
+  mode: { templateOnly: boolean },
 ): Promise<void> {
   const document = await resolveTargetDocument(uri);
   if (!document) {
@@ -51,31 +59,39 @@ async function previewGeneratedOutput(
     return;
   }
 
-  let brickVariables;
-  let brickGen;
-  try {
-    brickVariables = loadBrickVariables(scope.brickYamlPath);
-    brickGen = loadBrickGenOptions(scope.scopeDir);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    void vscode.window.showErrorMessage(
-      `Could not load brick configuration: ${message}`,
+  let selectedValues: Record<string, string | boolean> | undefined;
+
+  if (!mode.templateOnly) {
+    let brickVariables;
+    let brickGen;
+    try {
+      brickVariables = loadBrickVariables(scope.brickYamlPath);
+      brickGen = loadBrickGenOptions(scope.scopeDir);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      void vscode.window.showErrorMessage(
+        `Could not load brick configuration: ${message}`,
+      );
+      return;
+    }
+
+    const variables = resolvePreviewVariables(
+      brickVariables,
+      document.getText(),
+      brickGen,
     );
-    return;
-  }
+    const savedValues = loadSavedPreviewVariables(
+      context,
+      scope.scopeName,
+      variables,
+    );
+    selectedValues = await collectPreviewVariableValues(variables, savedValues);
+    if (selectedValues === undefined) {
+      return;
+    }
 
-  const variables = resolvePreviewVariables(
-    brickVariables,
-    document.getText(),
-    brickGen,
-  );
-  const savedValues = loadSavedPreviewVariables(context, scope.scopeName, variables);
-  const selectedValues = await collectPreviewVariableValues(variables, savedValues);
-  if (selectedValues === undefined) {
-    return;
+    await savePreviewVariables(context, scope.scopeName, selectedValues);
   }
-
-  await savePreviewVariables(context, scope.scopeName, selectedValues);
 
   let cliCommand: string;
   try {
@@ -86,10 +102,15 @@ async function previewGeneratedOutput(
     return;
   }
 
+  const progressTitle = mode.templateOnly
+    ? 'Generating template preview…'
+    : 'Generating preview…';
+  const diffTitlePrefix = mode.templateOnly ? 'Template preview' : 'Preview';
+
   await vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,
-      title: 'Generating preview…',
+      title: progressTitle,
       cancellable: false,
     },
     async () => {
@@ -99,8 +120,9 @@ async function previewGeneratedOutput(
           filePath: document.fileName,
           vars: selectedValues,
           cliCommand,
+          templateOnly: mode.templateOnly,
         });
-        await openPreviewDiff(document, previewContent);
+        await openPreviewDiff(document, previewContent, diffTitlePrefix);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         void vscode.window.showErrorMessage(`Preview failed: ${message}`);
@@ -128,12 +150,13 @@ async function resolveTargetDocument(
 async function openPreviewDiff(
   original: vscode.TextDocument,
   previewContent: string,
+  titlePrefix: string,
 ): Promise<void> {
   const previewDocument = await vscode.workspace.openTextDocument({
     content: previewContent,
     language: original.languageId,
   });
-  const title = `Preview: ${path.basename(original.fileName)}`;
+  const title = `${titlePrefix}: ${path.basename(original.fileName)}`;
   await vscode.commands.executeCommand(
     'vscode.diff',
     original.uri,

--- a/tools/vscode_extension/src/previewRunner.ts
+++ b/tools/vscode_extension/src/previewRunner.ts
@@ -10,8 +10,9 @@ const execFileAsync = promisify(execFile);
 export async function runPreviewCommand(options: {
   scope: BrickScopeInfo;
   filePath: string;
-  vars: Record<string, PreviewVarValue>;
+  vars?: Record<string, PreviewVarValue>;
   cliCommand: string;
+  templateOnly?: boolean;
 }): Promise<string> {
   const args = [
     'preview',
@@ -23,9 +24,13 @@ export async function runPreviewCommand(options: {
     options.scope.monorepoRoot,
   ];
 
-  const varsArg = formatVarsForCli(options.vars);
-  if (varsArg.length > 0) {
-    args.push('--vars', varsArg);
+  if (options.templateOnly) {
+    args.push('--template-only');
+  } else {
+    const varsArg = formatVarsForCli(options.vars ?? {});
+    if (varsArg.length > 0) {
+      args.push('--vars', varsArg);
+    }
   }
 
   try {


### PR DESCRIPTION
## Summary

- Add **Brick Generator: Preview template output** command that calls `brick_generator preview --template-only` (no variable quick-pick).
- Add a matching CodeLens on the first annotation and document generated vs template preview in the extension README.

Depends on #977 for the `--template-only` CLI flag.